### PR TITLE
feat: Add tests for use-isnan and valid-typeof rules

### DIFF
--- a/rules/core/use-isnan.test.js
+++ b/rules/core/use-isnan.test.js
@@ -1,0 +1,37 @@
+const { Linter } = require('eslint')
+const { RuleTester } = require('eslint')
+
+const linter = new Linter()
+const rule = linter.getRules().get('use-isnan')
+
+const ruleTester = new RuleTester()
+
+ruleTester.run('use-isnan', rule, {
+  valid: [
+    'isNaN(foo)',
+    'isNaN(NaN)',
+    'Number.isNaN(foo)',
+    'Number.isNaN(NaN)',
+    'foo()',
+    'var foo = isNaN(NaN)',
+    'var foo = Number.isNaN(NaN)',
+  ],
+  invalid: [
+    {
+      code: 'foo == NaN',
+      errors: [{ message: "Use the isNaN function to compare with NaN." }],
+    },
+    {
+      code: 'foo != NaN',
+      errors: [{ message: "Use the isNaN function to compare with NaN." }],
+    },
+    {
+      code: 'foo === NaN',
+      errors: [{ message: "Use the isNaN function to compare with NaN." }],
+    },
+    {
+      code: 'foo !== NaN',
+      errors: [{ message: "Use the isNaN function to compare with NaN." }],
+    },
+  ],
+})

--- a/rules/core/valid-typeof.test.js
+++ b/rules/core/valid-typeof.test.js
@@ -1,0 +1,38 @@
+const { Linter } = require('eslint')
+const { RuleTester } = require('eslint')
+
+const linter = new Linter()
+const rule = linter.getRules().get('valid-typeof')
+
+const ruleTester = new RuleTester()
+
+ruleTester.run('valid-typeof', rule, {
+  valid: [
+    `typeof foo === 'string'`,
+    `typeof foo === 'object'`,
+    `typeof foo === 'function'`,
+    `typeof foo === 'undefined'`,
+    `typeof foo === 'boolean'`,
+    `typeof foo === 'number'`,
+    `typeof foo === 'symbol'`,
+    `typeof foo === 'bigint'`,
+    `typeof foo == 'string'`,
+    `'string' === typeof foo`,
+    `'object' === typeof foo`,
+    `'function' === typeof foo`,
+  ],
+  invalid: [
+    {
+      code: `typeof foo === 'strnig'`,
+      errors: [{ message: 'Invalid typeof comparison value.' }],
+    },
+    {
+      code: `typeof foo === 'undefimed'`,
+      errors: [{ message: 'Invalid typeof comparison value.' }],
+    },
+    {
+      code: `typeof foo === 'nunber'`,
+      errors: [{ message: 'Invalid typeof comparison value.' }],
+    },
+  ],
+})

--- a/test-creation-progress.md
+++ b/test-creation-progress.md
@@ -170,5 +170,5 @@
 | rest-spread-spacing | implemented | [rules/core/rest-spread-spacing/test.js](rules/core/rest-spread-spacing/test.js) |
 | strict | implemented | [rules/core/strict/test.js](rules/core/strict/test.js) |
 | unicode-bom | implemented | [rules/core/unicode-bom/test.js](rules/core/unicode-bom/test.js) |
-| use-isnan | pending | |
-| valid-typeof | pending | |
+| use-isnan | implemented | [rules/core/use-isnan.test.js](rules/core/use-isnan.test.js) |
+| valid-typeof | implemented | [rules/core/valid-typeof.test.js](rules/core/valid-typeof.test.js) |


### PR DESCRIPTION
This commit adds test files for the `use-isnan` and `valid-typeof` ESLint rules. The tests include both valid and invalid cases to ensure the rules are working as expected.

The `test-creation-progress.md` file has been updated to reflect the implementation of these tests.