### PR TITLE
Add null guarding inside of components

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -72,6 +72,7 @@ module.exports = [
       '@kaliber/no-relative-parent-import': 'warn',
       '@kaliber/jsx-key': 'warn',
       '@kaliber/import-sort': 'warn',
+      '@kaliber/no-component-return-null': 'warn',
 
       // ─── @stylistic rules (migrated from deprecated core rules) ──
       '@stylistic/brace-style': ['warn', '1tbs', { allowSingleLine: true }],

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const plugin = {
     'jsx-key': require('./rules/jsx-key'),
     'import-sort': require('./rules/import-sort'),
     'position-center': require('./rules/position-center'),
+    'no-component-return-null': require('./rules/no-component-return-null'),
 
     'data-x-required': require('./rules/data-x-required'),
     'data-x-latin-only': require('./rules/data-x-latin-only'),

--- a/rules/no-component-return-null/index.js
+++ b/rules/no-component-return-null/index.js
@@ -1,0 +1,103 @@
+const { firstLetterLowerCase } = require('../../machinery/word')
+const docsUrl = require('../../machinery/docsUrl')
+
+const messages = {
+  'no return null':
+    `Avoid returning \`null\` from a component. When this component is rendered universally ` +
+    `(client-side), the build tool calls \`.slice()\` on its result and \`null\` will throw. ` +
+    `Return an empty fragment \`<></>\` instead, or render this component conditionally from its parent.`,
+}
+
+module.exports = {
+  messages,
+
+  meta: {
+    type: 'problem',
+    hasSuggestions: true,
+    docs: {
+      description: 'Disallow returning `null` from components — it breaks `.slice()` during universal (client-side) rendering',
+      url: docsUrl(__dirname),
+    },
+  },
+
+  create(context) {
+    return {
+      ReturnStatement(node) {
+        if (!node.argument || !yieldsNull(node.argument)) return
+
+        const fn = getEnclosingFunction(node)
+        if (!fn || !isComponent(fn)) return
+
+        report(node, node.argument)
+      },
+
+      ArrowFunctionExpression(node) {
+        if (node.body.type === 'BlockStatement' || !yieldsNull(node.body)) return
+        if (!isComponent(node)) return
+
+        report(node.body, node.body)
+      },
+    }
+
+    function report(node, valueNode) {
+      context.report({
+        node,
+        message: messages['no return null'],
+        suggest: [
+          {
+            desc: 'Replace `null` with an empty fragment `<></>`',
+            fix(fixer) {
+              return getNullNodes(valueNode).map(nullNode => fixer.replaceText(nullNode, '<></>'))
+            },
+          },
+        ],
+      })
+    }
+  },
+}
+
+function isComponent(fn) {
+  const name = getComponentName(fn)
+  return Boolean(name) && !firstLetterLowerCase(name)
+}
+
+function getComponentName(fn) {
+  if (fn.id) return fn.id.name
+
+  const { parent } = fn
+  if (parent && parent.type === 'VariableDeclarator' && parent.id.type === 'Identifier') return parent.id.name
+
+  // const Component = forwardRef(() => …) / memo(() => …)
+  if (parent && parent.type === 'CallExpression') {
+    const grandParent = parent.parent
+    if (grandParent && grandParent.type === 'VariableDeclarator' && grandParent.id.type === 'Identifier') return grandParent.id.name
+  }
+
+  return null
+}
+
+function getEnclosingFunction(node) {
+  const functionTypes = ['FunctionDeclaration', 'FunctionExpression', 'ArrowFunctionExpression']
+  let current = node.parent
+  while (current) {
+    if (functionTypes.includes(current.type)) return current
+    current = current.parent
+  }
+  return null
+}
+
+function yieldsNull(node) {
+  if (isNullLiteral(node)) return true
+  if (node.type === 'ConditionalExpression') return yieldsNull(node.consequent) || yieldsNull(node.alternate)
+  return false
+}
+
+function getNullNodes(node) {
+  if (isNullLiteral(node)) return [node]
+  if (node.type === 'ConditionalExpression') return [...getNullNodes(node.consequent), ...getNullNodes(node.alternate)]
+  return []
+}
+
+function isNullLiteral(node) {
+  return node.type === 'Literal' && node.value === null && node.raw === 'null'
+}

--- a/rules/no-component-return-null/index.js
+++ b/rules/no-component-return-null/index.js
@@ -5,7 +5,7 @@ const messages = {
   'no return null':
     `Avoid returning \`null\` from a component. When this component is rendered universally ` +
     `(client-side), the build tool calls \`.slice()\` on its result and \`null\` will throw. ` +
-    `Return an empty fragment \`<></>\` instead, or render this component conditionally from its parent.`,
+    `Render this component conditionally from its parent instead of returning \`null\`.`,
 }
 
 module.exports = {
@@ -13,7 +13,6 @@ module.exports = {
 
   meta: {
     type: 'problem',
-    hasSuggestions: true,
     docs: {
       description: 'Disallow returning `null` from components — it breaks `.slice()` during universal (client-side) rendering',
       url: docsUrl(__dirname),
@@ -28,29 +27,21 @@ module.exports = {
         const fn = getEnclosingFunction(node)
         if (!fn || !isComponent(fn)) return
 
-        report(node, node.argument)
+        report(node)
       },
 
       ArrowFunctionExpression(node) {
         if (node.body.type === 'BlockStatement' || !yieldsNull(node.body)) return
         if (!isComponent(node)) return
 
-        report(node.body, node.body)
+        report(node.body)
       },
     }
 
-    function report(node, valueNode) {
+    function report(node) {
       context.report({
         node,
         message: messages['no return null'],
-        suggest: [
-          {
-            desc: 'Replace `null` with an empty fragment `<></>`',
-            fix(fixer) {
-              return getNullNodes(valueNode).map(nullNode => fixer.replaceText(nullNode, '<></>'))
-            },
-          },
-        ],
       })
     }
   },
@@ -89,12 +80,6 @@ function yieldsNull(node) {
   if (isNullLiteral(node)) return true
   if (node.type === 'ConditionalExpression') return yieldsNull(node.consequent) || yieldsNull(node.alternate)
   return false
-}
-
-function getNullNodes(node) {
-  if (isNullLiteral(node)) return [node]
-  if (node.type === 'ConditionalExpression') return [...getNullNodes(node.consequent), ...getNullNodes(node.alternate)]
-  return []
 }
 
 function isNullLiteral(node) {

--- a/rules/no-component-return-null/index.js
+++ b/rules/no-component-return-null/index.js
@@ -67,11 +67,10 @@ function getComponentName(fn) {
   const { parent } = fn
   if (parent && parent.type === 'VariableDeclarator' && parent.id.type === 'Identifier') return parent.id.name
 
-  // const Component = forwardRef(() => …) / memo(() => …)
-  if (parent && parent.type === 'CallExpression') {
-    const grandParent = parent.parent
-    if (grandParent && grandParent.type === 'VariableDeclarator' && grandParent.id.type === 'Identifier') return grandParent.id.name
-  }
+  // const Component = forwardRef(() => …) / memo(forwardRef(() => …))
+  let current = parent
+  while (current && current.type === 'CallExpression') current = current.parent
+  if (current && current.type === 'VariableDeclarator' && current.id.type === 'Identifier') return current.id.name
 
   return null
 }

--- a/rules/no-component-return-null/readme.md
+++ b/rules/no-component-return-null/readme.md
@@ -4,7 +4,7 @@ Disallow returning `null` from a component.
 
 When a component is rendered universally (client-side rendering), the build tool calls `.slice()` on the component's result. If the component returns `null`, that call throws and rendering breaks. This is easy to miss because the same component renders fine server-side, so the failure only shows up once it is used as a universal/client component.
 
-Instead of returning `null`, return an empty fragment `<></>`, or move the condition up so the parent decides whether to render the component at all.
+Instead of returning `null`, move the condition up so the parent decides whether to render the component at all. A component should always render something — it should never have to check whether it should render itself.
 
 This rule only targets components — functions whose name starts with an uppercase letter. It does not flag `null` returned from hooks, helper functions, or callbacks (e.g. inside `.map()`), and it does not flag `null` used inside JSX (`{cond ? <X /> : null}`).
 
@@ -13,8 +13,11 @@ This rule only targets components — functions whose name starts with an upperc
 Examples of *correct* code for this rule:
 
 ```jsx
+function Parent({ prop }) {
+  return <div>{prop && <Card prop={prop} />}</div>
+}
+
 function Card({ prop }) {
-  if (!prop) return <></>
   return <div>{prop}</div>
 }
 ```
@@ -39,8 +42,7 @@ function Card({ prop }) {
 }
 ```
 ```jsx
-const Card = ({ prop }) => prop ? <div /> : null
-```
-```jsx
-const Card = () => null
+function Card({ prop }) {
+  return prop ? <div /> : null
+}
 ```

--- a/rules/no-component-return-null/readme.md
+++ b/rules/no-component-return-null/readme.md
@@ -1,0 +1,46 @@
+# No component return null
+
+Disallow returning `null` from a component.
+
+When a component is rendered universally (client-side rendering), the build tool calls `.slice()` on the component's result. If the component returns `null`, that call throws and rendering breaks. This is easy to miss because the same component renders fine server-side, so the failure only shows up once it is used as a universal/client component.
+
+Instead of returning `null`, return an empty fragment `<></>`, or move the condition up so the parent decides whether to render the component at all.
+
+This rule only targets components — functions whose name starts with an uppercase letter. It does not flag `null` returned from hooks, helper functions, or callbacks (e.g. inside `.map()`), and it does not flag `null` used inside JSX (`{cond ? <X /> : null}`).
+
+## Examples
+
+Examples of *correct* code for this rule:
+
+```jsx
+function Card({ prop }) {
+  if (!prop) return <></>
+  return <div>{prop}</div>
+}
+```
+```jsx
+function List({ items }) {
+  return <ul>{items.map(item => item ? <li key={item.id} /> : null)}</ul>
+}
+```
+```js
+function getValue(prop) {
+  if (!prop) return null
+  return prop.value
+}
+```
+
+Examples of *incorrect* code for this rule:
+
+```jsx
+function Card({ prop }) {
+  if (!prop) return null
+  return <div>{prop}</div>
+}
+```
+```jsx
+const Card = ({ prop }) => prop ? <div /> : null
+```
+```jsx
+const Card = () => null
+```

--- a/rules/no-component-return-null/test.js
+++ b/rules/no-component-return-null/test.js
@@ -1,8 +1,6 @@
 const { messages } = require('./')
 const { test } = require('../../machinery/test')
 
-const desc = 'Replace `null` with an empty fragment `<></>`'
-
 test('no-component-return-null', {
   valid: [
     // component returning JSX
@@ -31,7 +29,6 @@ test('no-component-return-null', {
       errors: [{
         message: messages['no return null'],
         type: 'ReturnStatement',
-        suggestions: [{ desc, output: `function Card({ prop }) { if (!prop) return <></>; return <div /> }` }],
       }],
     },
 
@@ -41,7 +38,6 @@ test('no-component-return-null', {
       errors: [{
         message: messages['no return null'],
         type: 'ReturnStatement',
-        suggestions: [{ desc, output: `const Card = ({ prop }) => { if (!prop) return <></>; return <div /> }` }],
       }],
     },
 
@@ -51,7 +47,6 @@ test('no-component-return-null', {
       errors: [{
         message: messages['no return null'],
         type: 'Literal',
-        suggestions: [{ desc, output: `const Card = () => <></>` }],
       }],
     },
 
@@ -61,7 +56,6 @@ test('no-component-return-null', {
       errors: [{
         message: messages['no return null'],
         type: 'ReturnStatement',
-        suggestions: [{ desc, output: `function Card({ prop }) { return prop ? <div /> : <></> }` }],
       }],
     },
 
@@ -71,7 +65,6 @@ test('no-component-return-null', {
       errors: [{
         message: messages['no return null'],
         type: 'ConditionalExpression',
-        suggestions: [{ desc, output: `const Card = ({ prop }) => prop ? <div /> : <></>` }],
       }],
     },
 
@@ -81,7 +74,6 @@ test('no-component-return-null', {
       errors: [{
         message: messages['no return null'],
         type: 'ReturnStatement',
-        suggestions: [{ desc, output: `const Card = React.forwardRef(({ prop }) => { if (!prop) return <></>; return <div /> })` }],
       }],
     },
 
@@ -91,7 +83,6 @@ test('no-component-return-null', {
       errors: [{
         message: messages['no return null'],
         type: 'ReturnStatement',
-        suggestions: [{ desc, output: `const Card = React.memo(React.forwardRef(({ prop }) => { if (!prop) return <></>; return <div /> }))` }],
       }],
     },
   ],

--- a/rules/no-component-return-null/test.js
+++ b/rules/no-component-return-null/test.js
@@ -84,5 +84,15 @@ test('no-component-return-null', {
         suggestions: [{ desc, output: `const Card = React.forwardRef(({ prop }) => { if (!prop) return <></>; return <div /> })` }],
       }],
     },
+
+    // component wrapped in nested memo(forwardRef(...))
+    {
+      code: `const Card = React.memo(React.forwardRef(({ prop }) => { if (!prop) return null; return <div /> }))`,
+      errors: [{
+        message: messages['no return null'],
+        type: 'ReturnStatement',
+        suggestions: [{ desc, output: `const Card = React.memo(React.forwardRef(({ prop }) => { if (!prop) return <></>; return <div /> }))` }],
+      }],
+    },
   ],
 })

--- a/rules/no-component-return-null/test.js
+++ b/rules/no-component-return-null/test.js
@@ -1,0 +1,88 @@
+const { messages } = require('./')
+const { test } = require('../../machinery/test')
+
+const desc = 'Replace `null` with an empty fragment `<></>`'
+
+test('no-component-return-null', {
+  valid: [
+    // component returning JSX
+    `function Card({ prop }) { return <div>{prop}</div> }`,
+
+    // null inside JSX is fine — it is not a component return
+    `function Card({ prop }) { return <div>{prop ? <span /> : null}</div> }`,
+
+    // null returned from a callback inside a component
+    `function List({ items }) { return <ul>{items.map(item => item ? <li /> : null)}</ul> }`,
+
+    // non-component function (lowercase) may return null
+    `function getValue(prop) { if (!prop) return null; return prop.value }`,
+
+    // hooks may return null
+    `function useThing() { return null }`,
+
+    // helper function inside a component may return null
+    `function Card() { function helper() { return null } return <div /> }`,
+  ],
+
+  invalid: [
+    // early return null
+    {
+      code: `function Card({ prop }) { if (!prop) return null; return <div /> }`,
+      errors: [{
+        message: messages['no return null'],
+        type: 'ReturnStatement',
+        suggestions: [{ desc, output: `function Card({ prop }) { if (!prop) return <></>; return <div /> }` }],
+      }],
+    },
+
+    // arrow component, early return null
+    {
+      code: `const Card = ({ prop }) => { if (!prop) return null; return <div /> }`,
+      errors: [{
+        message: messages['no return null'],
+        type: 'ReturnStatement',
+        suggestions: [{ desc, output: `const Card = ({ prop }) => { if (!prop) return <></>; return <div /> }` }],
+      }],
+    },
+
+    // arrow component, implicit null return
+    {
+      code: `const Card = () => null`,
+      errors: [{
+        message: messages['no return null'],
+        type: 'Literal',
+        suggestions: [{ desc, output: `const Card = () => <></>` }],
+      }],
+    },
+
+    // ternary returning null
+    {
+      code: `function Card({ prop }) { return prop ? <div /> : null }`,
+      errors: [{
+        message: messages['no return null'],
+        type: 'ReturnStatement',
+        suggestions: [{ desc, output: `function Card({ prop }) { return prop ? <div /> : <></> }` }],
+      }],
+    },
+
+    // arrow component, implicit ternary null return
+    {
+      code: `const Card = ({ prop }) => prop ? <div /> : null`,
+      errors: [{
+        message: messages['no return null'],
+        type: 'ConditionalExpression',
+        suggestions: [{ desc, output: `const Card = ({ prop }) => prop ? <div /> : <></>` }],
+      }],
+    },
+
+    // component wrapped in forwardRef
+    {
+      code: `const Card = React.forwardRef(({ prop }) => { if (!prop) return null; return <div /> })`,
+      errors: [{
+        message: messages['no return null'],
+        type: 'ReturnStatement',
+        suggestions: [{ desc, output: `const Card = React.forwardRef(({ prop }) => { if (!prop) return <></>; return <div /> })` }],
+      }],
+    },
+  ],
+})


### PR DESCRIPTION
Adding `if (!x) return null` to a component makes it break if the component is used with CSR. See https://github.com/Kaliber/kaliber-build/blob/366a1164fd7a45e6964e10c9b3354b378af8aeed/library/lib/universal/client.js#L36 

It will try to `.slice()` null or undefined depending on the setup. This rule warns the user that this behavior can occur and hints at the usage of conditional rendering in a parent component. 

<img width="1626" height="76" alt="Screenshot 2026-06-18 at 23 52 14" src="https://github.com/user-attachments/assets/a662e866-12be-48a2-acc3-88af24b4dc9e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new `no-component-return-null` ESLint rule that identifies when components return `null` directly. Configured to warn by default in the ESLint configuration.

* **Documentation**
  * Comprehensive documentation added for the new rule, including valid and invalid usage examples.

* **Tests**
  * Added test suite covering multiple component return patterns, edge cases, and various component declaration forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->