### PR TITLE
Feature/no null return in universal

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -72,6 +72,7 @@ module.exports = [
       '@kaliber/no-relative-parent-import': 'warn',
       '@kaliber/jsx-key': 'warn',
       '@kaliber/import-sort': 'warn',
+      '@kaliber/no-null-return-in-universal': 'warn',
 
       // ─── @stylistic rules (migrated from deprecated core rules) ──
       '@stylistic/brace-style': ['warn', '1tbs', { allowSingleLine: true }],

--- a/index.js
+++ b/index.js
@@ -29,6 +29,8 @@ const plugin = {
     'data-x-form-naming': require('./rules/data-x-form-naming'),
 
     'todo-ticket-reference': require('./rules/todo-ticket-reference'),
+
+    'no-null-return-in-universal': require('./rules/no-null-return-in-universal'),
   },
 
   configs: {},

--- a/machinery/filename.js
+++ b/machinery/filename.js
@@ -1,7 +1,7 @@
 const path = require('node:path')
 
 module.exports = {
-  isApp, isPage, isTemplate,
+  isApp, isPage, isTemplate, isUniversal,
   getBaseFilename,
 }
 
@@ -18,6 +18,11 @@ function isPage(context) {
 function isTemplate(context) {
   const filename = context.filename
   return /.+\.[^.]+\.js/.test(filename)
+}
+
+function isUniversal(context) {
+  const filename = context.filename
+  return !!filename && filename.endsWith('.universal.js')
 }
 
 function getBaseFilename(context) {

--- a/rules/no-null-return-in-universal/fixtures/BadComponent.js
+++ b/rules/no-null-return-in-universal/fixtures/BadComponent.js
@@ -1,0 +1,4 @@
+export default function BadComponent({ show }) {
+  if (!show) return null
+  return <div>Content</div>
+}

--- a/rules/no-null-return-in-universal/fixtures/GoodComponent.js
+++ b/rules/no-null-return-in-universal/fixtures/GoodComponent.js
@@ -1,0 +1,3 @@
+export default function GoodComponent({ name }) {
+  return <div>{name}</div>
+}

--- a/rules/no-null-return-in-universal/fixtures/LogicalAndComponent.js
+++ b/rules/no-null-return-in-universal/fixtures/LogicalAndComponent.js
@@ -1,0 +1,3 @@
+export default function LogicalAndComponent({ show }) {
+  return show && <div>Content</div>
+}

--- a/rules/no-null-return-in-universal/fixtures/NamedBadComponent.js
+++ b/rules/no-null-return-in-universal/fixtures/NamedBadComponent.js
@@ -1,0 +1,4 @@
+export function NamedBadComponent({ show }) {
+  if (!show) return null
+  return <div>Content</div>
+}

--- a/rules/no-null-return-in-universal/index.js
+++ b/rules/no-null-return-in-universal/index.js
@@ -1,3 +1,6 @@
+const fs = require('node:fs')
+const nodePath = require('node:path')
+const espree = require('espree')
 const { firstLetterLowerCase } = require('../../machinery/word')
 const { isUniversal } = require('../../machinery/filename')
 const docsUrl = require('../../machinery/docsUrl')
@@ -14,6 +17,18 @@ const messages = {
   'no logical and return':
     `Unexpected logical && return in universal component — when the condition is falsy, ` +
     `this crashes @kaliber/build. Use a ternary with a non-rendering element instead.`,
+
+  'source component may return null': componentName =>
+    `Component '${componentName}' re-exported as universal can return null — ` +
+    `this crashes @kaliber/build. Ensure it always returns a valid element.`,
+
+  'source component may return empty fragment': componentName =>
+    `Component '${componentName}' re-exported as universal can return an empty fragment — ` +
+    `this crashes @kaliber/build. Ensure it always returns a valid element.`,
+
+  'source component may use logical and': componentName =>
+    `Component '${componentName}' re-exported as universal uses a logical && return — ` +
+    `when the condition is falsy, this crashes @kaliber/build.`,
 }
 
 module.exports = {
@@ -35,6 +50,39 @@ module.exports = {
         if (!isInsideComponentFunction(node)) return
         checkReturnValue(node.argument)
       },
+
+      // export { default } from './Component'
+      // export { Component as default } from './Component'
+      ExportNamedDeclaration(node) {
+        if (!node.source) return
+        const defaultSpec = node.specifiers.find(s => s.exported.name === 'default')
+        if (!defaultSpec) return
+
+        const exportedName = defaultSpec.local.name
+        checkReExportedSource(node, node.source.value, exportedName)
+      },
+
+      // import { X } from './X'; export default X
+      ExportDefaultDeclaration(node) {
+        if (node.declaration.type !== 'Identifier') return
+
+        const name = node.declaration.name
+        const importDecl = findImportForIdentifier(name)
+        if (!importDecl) return
+
+        const spec = importDecl.specifiers.find(s => s.local.name === name)
+        if (!spec) return
+
+        const exportedName = spec.type === 'ImportDefaultSpecifier' ? 'default' : spec.imported.name
+        checkReExportedSource(node, importDecl.source.value, exportedName)
+      },
+    }
+
+    function findImportForIdentifier(name) {
+      return context.sourceCode.ast.body.find(
+        node => node.type === 'ImportDeclaration' &&
+          node.specifiers.some(s => s.local.name === name)
+      )
     }
 
     function checkReturnValue(expression) {
@@ -69,8 +117,31 @@ module.exports = {
         })
       }
     }
+
+    function checkReExportedSource(reportNode, importSource, exportedName) {
+      const resolvedPath = resolveImportPath(context.filename, importSource)
+      if (!resolvedPath) return
+
+      const sourceAst = parseFile(resolvedPath)
+      if (!sourceAst) return
+
+      const componentNode = findExportedComponent(sourceAst, exportedName)
+      if (!componentNode) return
+
+      const componentName = componentNode.id ? componentNode.id.name : exportedName
+      const problems = findNullReturnProblems(componentNode)
+
+      for (const problem of problems) {
+        context.report({
+          message: messages[problem](componentName),
+          node: reportNode,
+        })
+      }
+    }
   },
 }
+
+// ── AST checks (used for both inline and cross-file) ─────────────────
 
 function isInsideComponentFunction(node) {
   let current = node.parent
@@ -117,4 +188,130 @@ function hasMeaningfulChildren(node) {
     if (child.type === 'JSXText') return child.value.trim() !== ''
     return true
   })
+}
+
+// ── Cross-file analysis ──────────────────────────────────────────────
+
+function resolveImportPath(fromFile, importSource) {
+  if (!importSource.startsWith('.')) return null
+
+  const dir = nodePath.dirname(fromFile)
+  const resolved = nodePath.resolve(dir, importSource)
+
+  const candidates = [resolved, `${resolved}.js`, `${resolved}/index.js`]
+  return candidates.find(p => {
+    try { return fs.statSync(p).isFile() }
+    catch { return false }
+  })
+}
+
+function parseFile(filePath) {
+  try {
+    const source = fs.readFileSync(filePath, 'utf-8')
+    return espree.parse(source, {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+      ecmaFeatures: { jsx: true },
+    })
+  } catch {
+    return null
+  }
+}
+
+function findExportedComponent(ast, exportedName) {
+  for (const node of ast.body) {
+    if (exportedName === 'default') {
+      if (
+        node.type === 'ExportDefaultDeclaration' &&
+        isFunctionNode(node.declaration)
+      ) return node.declaration
+
+      if (
+        node.type === 'ExportDefaultDeclaration' &&
+        node.declaration.type === 'Identifier'
+      ) return findFunctionByName(ast, node.declaration.name)
+    }
+
+    if (
+      node.type === 'ExportNamedDeclaration' &&
+      node.declaration &&
+      isFunctionNode(node.declaration) &&
+      node.declaration.id &&
+      node.declaration.id.name === exportedName
+    ) return node.declaration
+
+    if (node.type === 'ExportNamedDeclaration' && node.specifiers) {
+      const spec = node.specifiers.find(s => s.exported.name === exportedName)
+      if (spec) return findFunctionByName(ast, spec.local.name)
+    }
+  }
+  return null
+}
+
+function findFunctionByName(ast, name) {
+  for (const node of ast.body) {
+    if (isFunctionNode(node) && node.id && node.id.name === name) return node
+
+    if (node.type === 'VariableDeclaration') {
+      for (const decl of node.declarations) {
+        if (decl.id.name === name && decl.init && isFunctionNode(decl.init)) return decl.init
+      }
+    }
+  }
+  return null
+}
+
+function isFunctionNode(node) {
+  return (
+    node.type === 'FunctionDeclaration' ||
+    node.type === 'FunctionExpression' ||
+    node.type === 'ArrowFunctionExpression'
+  )
+}
+
+/** Walk a function's body and find null-return problems (without parent refs). */
+function findNullReturnProblems(funcNode) {
+  const problems = []
+  walkReturns(funcNode.body, returnArg => {
+    if (!returnArg) return
+    checkExpression(returnArg)
+  })
+  return problems
+
+  function checkExpression(expr) {
+    if (isNullLiteral(expr)) {
+      problems.push('source component may return null')
+      return
+    }
+    if (isEmptyFragment(expr)) {
+      problems.push('source component may return empty fragment')
+      return
+    }
+    if (expr.type === 'ConditionalExpression') {
+      checkExpression(expr.consequent)
+      checkExpression(expr.alternate)
+      return
+    }
+    if (expr.type === 'LogicalExpression' && expr.operator === '&&') {
+      problems.push('source component may use logical and')
+    }
+  }
+}
+
+/** Walk a function body collecting return arguments, skipping nested functions. */
+function walkReturns(node, callback) {
+  if (!node || typeof node !== 'object') return
+  if (isFunctionNode(node)) return
+
+  if (node.type === 'ReturnStatement') {
+    callback(node.argument)
+    return
+  }
+
+  for (const key of Object.keys(node)) {
+    if (key === 'parent') continue
+    const child = node[key]
+    if (Array.isArray(child)) child.forEach(c => walkReturns(c, callback))
+    else if (child && typeof child.type === 'string') walkReturns(child, callback)
+  }
 }

--- a/rules/no-null-return-in-universal/index.js
+++ b/rules/no-null-return-in-universal/index.js
@@ -1,0 +1,120 @@
+const { firstLetterLowerCase } = require('../../machinery/word')
+const { isUniversal } = require('../../machinery/filename')
+const docsUrl = require('../../machinery/docsUrl')
+
+const messages = {
+  'no null return':
+    `Unexpected 'return null' in universal component — this crashes @kaliber/build. ` +
+    `Return a non-rendering element like <span hidden /> instead.`,
+
+  'no empty fragment return':
+    `Unexpected empty fragment return in universal component — this crashes @kaliber/build. ` +
+    `Return a non-rendering element like <span hidden /> instead.`,
+
+  'no logical and return':
+    `Unexpected logical && return in universal component — when the condition is falsy, ` +
+    `this crashes @kaliber/build. Use a ternary with a non-rendering element instead.`,
+}
+
+module.exports = {
+  messages,
+
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow returning null, empty fragments, or implicitly falsy values from universal components',
+      url: docsUrl(__dirname),
+    },
+  },
+
+  create(context) {
+    if (!isUniversal(context)) return {}
+
+    return {
+      ReturnStatement(node) {
+        if (!isInsideComponentFunction(node)) return
+        checkReturnValue(node.argument)
+      },
+    }
+
+    function checkReturnValue(expression) {
+      if (!expression) return
+
+      if (isNullLiteral(expression)) {
+        context.report({
+          message: messages['no null return'],
+          node: expression,
+        })
+        return
+      }
+
+      if (isEmptyFragment(expression)) {
+        context.report({
+          message: messages['no empty fragment return'],
+          node: expression,
+        })
+        return
+      }
+
+      if (expression.type === 'ConditionalExpression') {
+        checkReturnValue(expression.consequent)
+        checkReturnValue(expression.alternate)
+        return
+      }
+
+      if (expression.type === 'LogicalExpression' && expression.operator === '&&') {
+        context.report({
+          message: messages['no logical and return'],
+          node: expression,
+        })
+      }
+    }
+  },
+}
+
+function isInsideComponentFunction(node) {
+  let current = node.parent
+  while (current) {
+    if (
+      current.type === 'FunctionDeclaration' ||
+      current.type === 'FunctionExpression' ||
+      current.type === 'ArrowFunctionExpression'
+    ) {
+      return (
+        current.type === 'FunctionDeclaration' &&
+        current.id &&
+        !firstLetterLowerCase(current.id.name)
+      )
+    }
+    current = current.parent
+  }
+  return false
+}
+
+function isNullLiteral(node) {
+  return node.type === 'Literal' && node.value === null
+}
+
+function isEmptyFragment(node) {
+  if (node.type === 'JSXFragment') return !hasMeaningfulChildren(node)
+
+  if (node.type === 'JSXElement') {
+    const { name } = node.openingElement
+    const isReactFragment =
+      (name.type === 'JSXIdentifier' && name.name === 'Fragment') ||
+      (name.type === 'JSXMemberExpression' &&
+        name.object.name === 'React' &&
+        name.property.name === 'Fragment')
+
+    return isReactFragment && !hasMeaningfulChildren(node)
+  }
+
+  return false
+}
+
+function hasMeaningfulChildren(node) {
+  return node.children.some(child => {
+    if (child.type === 'JSXText') return child.value.trim() !== ''
+    return true
+  })
+}

--- a/rules/no-null-return-in-universal/readme.md
+++ b/rules/no-null-return-in-universal/readme.md
@@ -1,0 +1,78 @@
+# No null return in universal
+
+Universal components (files ending in `.universal.js`) are rendered on both the server and client by `@kaliber/build`. Returning `null`, an empty fragment, or a value that can implicitly become falsy crashes the build process.
+
+This rule catches these patterns in any PascalCase function (component) within a `*.universal.js` file:
+
+- `return null`
+- `return <></>` (empty fragment)
+- `return <React.Fragment></React.Fragment>` (empty named fragment)
+- `return condition ? <X /> : null` (ternary with null branch)
+- `return condition && <X />` (logical `&&` — returns a falsy value when condition is false)
+
+## What to do instead
+
+Return a non-rendering element:
+
+```jsx
+<span hidden />
+```
+
+Or wrap conditionals in a ternary with a non-rendering fallback:
+
+```jsx
+return show ? <Component /> : <span hidden />
+```
+
+## Examples
+
+Examples of *correct* code for this rule:
+
+`Component.universal.js`:
+```jsx
+export default function Component({ show }) {
+  return show ? <Content /> : <span hidden />
+}
+```
+
+`Component.universal.js`:
+```jsx
+export default function Component({ children }) {
+  return <>{children}</>
+}
+```
+
+Examples of *incorrect* code for this rule:
+
+`Component.universal.js`:
+```jsx
+// ✗ returning null
+export default function Component({ show }) {
+  if (!show) return null
+  return <Content />
+}
+```
+
+`Component.universal.js`:
+```jsx
+// ✗ returning an empty fragment
+export default function Component() {
+  return <></>
+}
+```
+
+`Component.universal.js`:
+```jsx
+// ✗ ternary with null
+export default function Component({ show }) {
+  return show ? <Content /> : null
+}
+```
+
+`Component.universal.js`:
+```jsx
+// ✗ logical && (returns false when condition is falsy)
+export default function Component({ show }) {
+  return show && <Content />
+}
+```

--- a/rules/no-null-return-in-universal/test.js
+++ b/rules/no-null-return-in-universal/test.js
@@ -1,5 +1,8 @@
+const path = require('node:path')
 const { test } = require('../../machinery/test')
 const { messages } = require('.')
+
+const fixturesDir = path.resolve(__dirname, 'fixtures')
 
 test('no-null-return-in-universal', {
   valid: [
@@ -51,6 +54,11 @@ test('no-null-return-in-universal', {
           return <div>Content</div>
         }
       `,
+    },
+    {
+      // re-export of a component that never returns null
+      filename: path.join(fixturesDir, 'Wrapper.universal.js'),
+      code: `export { default } from './GoodComponent'`,
     },
   ],
   invalid: [
@@ -150,6 +158,34 @@ test('no-null-return-in-universal', {
         }
       `,
       errors: [{ message: messages['no empty fragment return'] }],
+    },
+    // ── Cross-file: re-export patterns ──────────────────────────────
+    {
+      // re-export of a component that returns null
+      filename: path.join(fixturesDir, 'Wrapper.universal.js'),
+      code: `export { default } from './BadComponent'`,
+      errors: [{ message: messages['source component may return null']('BadComponent') }],
+    },
+    {
+      // named re-export as default: export { X as default } from './X'
+      filename: path.join(fixturesDir, 'Wrapper.universal.js'),
+      code: `export { NamedBadComponent as default } from './NamedBadComponent'`,
+      errors: [{ message: messages['source component may return null']('NamedBadComponent') }],
+    },
+    {
+      // import + re-export: import X from './X'; export default X
+      filename: path.join(fixturesDir, 'Wrapper.universal.js'),
+      code: `
+        import BadComponent from './BadComponent'
+        export default BadComponent
+      `,
+      errors: [{ message: messages['source component may return null']('BadComponent') }],
+    },
+    {
+      // re-export of a component that uses logical &&
+      filename: path.join(fixturesDir, 'Wrapper.universal.js'),
+      code: `export { default } from './LogicalAndComponent'`,
+      errors: [{ message: messages['source component may use logical and']('LogicalAndComponent') }],
     },
   ],
 })

--- a/rules/no-null-return-in-universal/test.js
+++ b/rules/no-null-return-in-universal/test.js
@@ -42,6 +42,16 @@ test('no-null-return-in-universal', {
       filename: 'Component.universal.js',
       code: `export function Component({ children }) { return <React.Fragment>{children}</React.Fragment> }`,
     },
+    {
+      // early return of JSX inside if-guard is fine
+      filename: 'Component.universal.js',
+      code: `
+        export function Component({ loading }) {
+          if (loading) return <span hidden />
+          return <div>Content</div>
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -106,6 +116,40 @@ test('no-null-return-in-universal', {
       filename: 'Component.universal.js',
       code: `export default function Component() { return null }`,
       errors: [{ message: messages['no null return'] }],
+    },
+    {
+      // early return null inside if-guard
+      filename: 'Component.universal.js',
+      code: `
+        export function Component({ data }) {
+          if (!data) return null
+          return <div>{data.name}</div>
+        }
+      `,
+      errors: [{ message: messages['no null return'] }],
+    },
+    {
+      // multiple early returns, one is null
+      filename: 'Component.universal.js',
+      code: `
+        export function Component({ status }) {
+          if (status === 'loading') return <span hidden />
+          if (status === 'error') return null
+          return <div>Done</div>
+        }
+      `,
+      errors: [{ message: messages['no null return'] }],
+    },
+    {
+      // early return empty fragment
+      filename: 'Component.universal.js',
+      code: `
+        export function Component({ visible }) {
+          if (!visible) return <></>
+          return <div>Content</div>
+        }
+      `,
+      errors: [{ message: messages['no empty fragment return'] }],
     },
   ],
 })

--- a/rules/no-null-return-in-universal/test.js
+++ b/rules/no-null-return-in-universal/test.js
@@ -1,0 +1,111 @@
+const { test } = require('../../machinery/test')
+const { messages } = require('.')
+
+test('no-null-return-in-universal', {
+  valid: [
+    {
+      // return null in a non-universal file — rule is inactive
+      filename: 'Component.js',
+      code: `export function Component() { return null }`,
+    },
+    {
+      // returning JSX is fine
+      filename: 'Component.universal.js',
+      code: `export function Component() { return <div /> }`,
+    },
+    {
+      // lowercase function — not a component
+      filename: 'Component.universal.js',
+      code: `function helper() { return null }`,
+    },
+    {
+      // fragment with children is fine
+      filename: 'Component.universal.js',
+      code: `export function Component({ children }) { return <>{children}</> }`,
+    },
+    {
+      // ternary without null is fine
+      filename: 'Component.universal.js',
+      code: `export function Component({ show }) { return show ? <div /> : <span hidden /> }`,
+    },
+    {
+      // null inside a nested arrow (e.g. .map callback) — not a component return
+      filename: 'Component.universal.js',
+      code: `
+        export function Component({ items }) {
+          return <div>{items.map(x => x.visible ? <span /> : null)}</div>
+        }
+      `,
+    },
+    {
+      // React.Fragment with children is fine
+      filename: 'Component.universal.js',
+      code: `export function Component({ children }) { return <React.Fragment>{children}</React.Fragment> }`,
+    },
+  ],
+  invalid: [
+    {
+      // return null
+      filename: 'Component.universal.js',
+      code: `export function Component() { return null }`,
+      errors: [{ message: messages['no null return'] }],
+    },
+    {
+      // return empty fragment
+      filename: 'Component.universal.js',
+      code: `export function Component() { return <></> }`,
+      errors: [{ message: messages['no empty fragment return'] }],
+    },
+    {
+      // return empty React.Fragment
+      filename: 'Component.universal.js',
+      code: `export function Component() { return <React.Fragment></React.Fragment> }`,
+      errors: [{ message: messages['no empty fragment return'] }],
+    },
+    {
+      // return empty Fragment (named import)
+      filename: 'Component.universal.js',
+      code: `export function Component() { return <Fragment></Fragment> }`,
+      errors: [{ message: messages['no empty fragment return'] }],
+    },
+    {
+      // ternary with null in alternate
+      filename: 'Component.universal.js',
+      code: `export function Component({ show }) { return show ? <div /> : null }`,
+      errors: [{ message: messages['no null return'] }],
+    },
+    {
+      // ternary with null in consequent
+      filename: 'Component.universal.js',
+      code: `export function Component({ show }) { return show ? null : <div /> }`,
+      errors: [{ message: messages['no null return'] }],
+    },
+    {
+      // ternary with null in both branches
+      filename: 'Component.universal.js',
+      code: `export function Component({ show }) { return show ? null : null }`,
+      errors: [
+        { message: messages['no null return'] },
+        { message: messages['no null return'] },
+      ],
+    },
+    {
+      // nested ternary with null
+      filename: 'Component.universal.js',
+      code: `export function Component({ a, b }) { return a ? <div /> : b ? <span /> : null }`,
+      errors: [{ message: messages['no null return'] }],
+    },
+    {
+      // logical && return
+      filename: 'Component.universal.js',
+      code: `export function Component({ show }) { return show && <div /> }`,
+      errors: [{ message: messages['no logical and return'] }],
+    },
+    {
+      // default export component
+      filename: 'Component.universal.js',
+      code: `export default function Component() { return null }`,
+      errors: [{ message: messages['no null return'] }],
+    },
+  ],
+})


### PR DESCRIPTION
## What

Prevents returning non-renderable values from components in `*.universal.js` files — all of which crash `@kaliber/build`'s `.slice()` call during client-side rendering.

## The problem

When a universal component returns `null`, an empty fragment, or a falsy value from `&&`, the build process calls `.slice()` on that value and throws:

```
TypeError: Cannot read properties of null (reading 'slice')
```

This only surfaces client-side — the same component renders fine server-side, making it easy to miss.

## What this rule catches

| Pattern | Why it crashes |
|---|---|
| `return null` | `.slice(null)` throws |
| `return <></>` | Empty fragment → `.slice([])` fails |
| `return <React.Fragment></React.Fragment>` | Same as above |
| `return condition ? <X /> : null` | Null branch crashes when condition is falsy |
| `return condition && <X />` | Returns `false` when falsy → `.slice(false)` throws |

## Cross-file analysis

The rule also follows re-exports. If a universal file does:

```js
// Wrapper.universal.js
export { default } from './BadComponent'
```

The rule parses `BadComponent.js` and reports if it returns null — even though `BadComponent` itself is not a universal file.

Supported re-export patterns:
- `export { default } from './X'`
- `export { X as default } from './X'`
- `import X from './X'; export default X`

## What to do instead

Return a non-rendering element:

```jsx
// ✗ Bad
if (!data) return null

// ✓ Good
if (!data) return <span hidden />
```

Or use a ternary with a fallback:

```jsx
// ✗ Bad
return show && <Component />

// ✓ Good
return show ? <Component /> : <span hidden />
```

## Scope

- **Only fires in `*.universal.js` files** — non-universal components can safely return `null`
- Only checks PascalCase functions (components), not hooks, helpers, or callbacks
- Configured as `'warn'` by default

## Note

There is a related PR #33 (`no-component-return-null`) that takes a different approach — it flags `return null` in **all** components regardless of filename. This rule is more targeted (universal files only) but catches more crash patterns (empty fragments, logical `&&`), and includes cross-file re-export analysis.
