### PR TITLE
feat: add JSDoc baseline config preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,29 @@ module.exports = [
 | [`data-x-sectioning-elements`](rules/data-x-sectioning-elements/readme.md) | Sectioning HTML elements (section, header, footer, nav, etc.) must have data-x |
 | [`data-x-form-naming`](rules/data-x-form-naming/readme.md) | Form elements must have a data-x value ending with -form |
 
+### JSDoc baseline
+
+Available through the opt-in `configs.jsdoc` preset. This wires up a curated
+subset of [`eslint-plugin-jsdoc`](https://github.com/gajus/eslint-plugin-jsdoc)
+rules for contract hygiene — valid type syntax, param name matching, and defined
+type references.
+
+```js
+const kaliberPlugin = require('@kaliber/eslint-plugin')
+
+module.exports = [
+  ...kaliberConfig,
+  kaliberPlugin.configs.jsdoc,
+]
+```
+
+| Rule | Description |
+|---|---|
+| `jsdoc/require-jsdoc` | Exported functions must have a JSDoc comment (`publicOnly: true`) |
+| `jsdoc/valid-types` | Validates JSDoc type expressions for syntax correctness |
+| `jsdoc/check-param-names` | Ensures `@param` names match the actual function parameters |
+| `jsdoc/no-undefined-types` | Disallows undefined type references in JSDoc |
+
 ## Documentation
 
 Each rule is self-contained — implementation, tests, and documentation live together:

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const pkg = require('./package.json')
+const pluginJsdoc = require('eslint-plugin-jsdoc')
 
 const plugin = {
   meta: {
@@ -32,6 +33,25 @@ const plugin = {
   },
 
   configs: {},
+}
+
+plugin.configs.jsdoc = {
+  plugins: {
+    'jsdoc': pluginJsdoc,
+  },
+  rules: {
+    'jsdoc/require-jsdoc': ['warn', {
+      require: {
+        FunctionDeclaration: true,
+        ArrowFunctionExpression: true,
+        FunctionExpression: true,
+      },
+      publicOnly: true,
+    }],
+    'jsdoc/valid-types': 'warn',
+    'jsdoc/check-param-names': 'warn',
+    'jsdoc/no-undefined-types': 'warn',
+  },
 }
 
 module.exports = plugin

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "eslint": "^9.39.4",
     "eslint-import-resolver-node": "^0.4.0",
     "eslint-plugin-import-x": "^4.0.0",
+    "eslint-plugin-jsdoc": "^50.6.9",
     "eslint-plugin-jsx-a11y": "^6.10.0",
     "eslint-plugin-react": "^7.37.0",
     "eslint-plugin-react-hooks": "^7.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       eslint-plugin-import-x:
         specifier: ^4.0.0
         version: 4.16.2(eslint-import-resolver-node@0.4.0)(eslint@9.39.4)
+      eslint-plugin-jsdoc:
+        specifier: ^50.6.9
+        version: 50.8.0(eslint@9.39.4)
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.0
         version: 6.10.2(eslint@9.39.4)
@@ -179,6 +182,10 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@es-joy/jsdoccomment@0.50.2':
+    resolution: {integrity: sha512-YAdE/IJSpwbOTiaURNCKECdAwqrJuFiZhylmesBcIRawtYKnBR2wxPhoIewMg+Yu+QuYvHfJNReWpoxGBKOChA==}
+    engines: {node: '>=18'}
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -415,6 +422,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  are-docs-informative@0.0.2:
+    resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
+    engines: {node: '>=14'}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -522,6 +533,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  comment-parser@1.4.1:
+    resolution: {integrity: sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==}
+    engines: {node: '>= 12.0.0'}
 
   comment-parser@1.4.6:
     resolution: {integrity: sha512-ObxuY6vnbWTN6Od72xfwN9DbzC7Y2vv8u1Soi9ahRKL37gb6y1qk6/dgjs+3JWuXJHWvsg3BXIwzd/rkmAwavg==}
@@ -658,6 +673,12 @@ packages:
         optional: true
       eslint-import-resolver-node:
         optional: true
+
+  eslint-plugin-jsdoc@50.8.0:
+    resolution: {integrity: sha512-UyGb5755LMFWPrZTEqqvTJ3urLz1iqj+bYOHFNag+sw3NvaMWP9K2z+uIn37XfNALmQLQyrBlJ5mkiVPL7ADEg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
 
   eslint-plugin-jsx-a11y@6.10.2:
     resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
@@ -974,6 +995,10 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  jsdoc-type-pratt-parser@4.1.0:
+    resolution: {integrity: sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==}
+    engines: {node: '>=12.0.0'}
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -1102,6 +1127,12 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-imports-exports@0.2.4:
+    resolution: {integrity: sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==}
+
+  parse-statements@1.0.11:
+    resolution: {integrity: sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1219,6 +1250,15 @@ packages:
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
+
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@4.0.0:
+    resolution: {integrity: sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==}
+
+  spdx-license-ids@3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
   stable-hash-x@0.2.0:
     resolution: {integrity: sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==}
@@ -1521,6 +1561,14 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@es-joy/jsdoccomment@0.50.2':
+    dependencies:
+      '@types/estree': 1.0.8
+      '@typescript-eslint/types': 8.59.0
+      comment-parser: 1.4.1
+      esquery: 1.7.0
+      jsdoc-type-pratt-parser: 4.1.0
+
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
     dependencies:
       eslint: 9.39.4
@@ -1722,6 +1770,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  are-docs-informative@0.0.2: {}
+
   argparse@2.0.1: {}
 
   aria-query@5.3.2: {}
@@ -1849,6 +1899,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  comment-parser@1.4.1: {}
 
   comment-parser@1.4.6: {}
 
@@ -2053,6 +2105,22 @@ snapshots:
       unrs-resolver: 1.11.1
     optionalDependencies:
       eslint-import-resolver-node: 0.4.0
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-jsdoc@50.8.0(eslint@9.39.4):
+    dependencies:
+      '@es-joy/jsdoccomment': 0.50.2
+      are-docs-informative: 0.0.2
+      comment-parser: 1.4.1
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint: 9.39.4
+      espree: 10.4.0
+      esquery: 1.7.0
+      parse-imports-exports: 0.2.4
+      semver: 7.7.4
+      spdx-expression-parse: 4.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -2439,6 +2507,8 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsdoc-type-pratt-parser@4.1.0: {}
+
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
@@ -2572,6 +2642,12 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-imports-exports@0.2.4:
+    dependencies:
+      parse-statements: 1.0.11
+
+  parse-statements@1.0.11: {}
 
   path-exists@4.0.0: {}
 
@@ -2717,6 +2793,15 @@ snapshots:
       side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
+
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@4.0.0:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.23
+
+  spdx-license-ids@3.0.23: {}
 
   stable-hash-x@0.2.0: {}
 

--- a/rules-overview.md
+++ b/rules-overview.md
@@ -9,6 +9,11 @@
 | @kaliber/naming-policy | Enforces a consistent naming policy for components, CSS files, variables, and refs to improve readability and enable tooling. | Custom | [rules/naming-policy/test.js](rules/naming-policy/test.js) | `"warn"` |
 | @kaliber/no-default-export | Prefers named exports over default exports to avoid ambiguity and refactoring issues. | Custom | [rules/no-default-export/test.js](rules/no-default-export/test.js) | `"warn"` |
 | @kaliber/no-relative-parent-import | Disallows relative parent imports (`../`) in favor of root-slash imports to prevent broken paths when moving files. | Custom | [rules/no-relative-parent-import/test.js](rules/no-relative-parent-import/test.js) | `"warn"` |
+| **JSDoc Baseline Rules** | | | | |
+| jsdoc/require-jsdoc | Exported functions must have a JSDoc comment. | [eslint-plugin-jsdoc](https://github.com/gajus/eslint-plugin-jsdoc) | [tests](https://github.com/gajus/eslint-plugin-jsdoc/tree/main/test) | opt-in `configs.jsdoc` |
+| jsdoc/valid-types | Validates JSDoc type expressions for syntax correctness. | [eslint-plugin-jsdoc](https://github.com/gajus/eslint-plugin-jsdoc) | [tests](https://github.com/gajus/eslint-plugin-jsdoc/tree/main/test) | opt-in `configs.jsdoc` |
+| jsdoc/check-param-names | Ensures @param names match the actual function parameters. | [eslint-plugin-jsdoc](https://github.com/gajus/eslint-plugin-jsdoc) | [tests](https://github.com/gajus/eslint-plugin-jsdoc/tree/main/test) | opt-in `configs.jsdoc` |
+| jsdoc/no-undefined-types | Disallows undefined type references in JSDoc. | [eslint-plugin-jsdoc](https://github.com/gajus/eslint-plugin-jsdoc) | [tests](https://github.com/gajus/eslint-plugin-jsdoc/tree/main/test) | opt-in `configs.jsdoc` |
 | **Third-Party Rules** | | | | |
 | **eslint-plugin-import** | | | | |
 | import/first | Ensure all imports appear before other statements | [eslint-plugin-import](https://github.com/import-js/eslint-plugin-import) | [tests](https://github.com/import-js/eslint-plugin-import/tree/main/tests) | `"warn"` |


### PR DESCRIPTION
## What

Adds a `configs.jsdoc` preset that wires up a curated subset of [`eslint-plugin-jsdoc`](https://github.com/gajus/eslint-plugin-jsdoc) rules for type contract hygiene.

## Usage

```js
const kaliberConfig = require('@kaliber/eslint-plugin/eslint.config')
const kaliberPlugin = require('@kaliber/eslint-plugin')

module.exports = [
  ...kaliberConfig,
  kaliberPlugin.configs.jsdoc,
]
```

## Rules

| Rule | What it enforces |
|---|---|
| `jsdoc/require-jsdoc` | Exported functions must have a JSDoc comment (`publicOnly: true`) |
| `jsdoc/valid-types` | JSDoc type expressions must be syntactically correct |
| `jsdoc/check-param-names` | `@param` names must match actual function parameters |
| `jsdoc/no-undefined-types` | Type references in JSDoc must be defined |

All rules are set to `'warn'`. `require-jsdoc` is scoped to exported functions only (`publicOnly: true`) — internal helpers don't need JSDoc.

## Why these four

This baseline ensures that public APIs have documented contracts and that existing JSDoc is correct. `require-jsdoc` on exports is the most impactful rule — it nudges teams toward documenting what other modules consume, which is where JSDoc pays for itself.

Not included (intentionally):
- `jsdoc/require-param-description` — descriptions are nice but not required
- `jsdoc/require-returns` — covered separately by `prose-require-type-predicate-jsdoc` for predicate functions

## Why opt-in

Like `configs.prose`, this is a per-project choice. Not every project uses JSDoc, and forcing it on projects that don't would just create noise.
