### PR TITLE
feat: add architectural lint rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ node_modules/
 .yarn-integrity
 .DS_Store
 .pnpm-store/
+.test-fixtures/

--- a/index.js
+++ b/index.js
@@ -29,9 +29,29 @@ const plugin = {
     'data-x-form-naming': require('./rules/data-x-form-naming'),
 
     'todo-ticket-reference': require('./rules/todo-ticket-reference'),
+
+    'no-restricted-layer-import': require('./rules/no-restricted-layer-import'),
+    'no-nested-component': require('./rules/no-nested-component'),
+    'no-universal-in-universal': require('./rules/no-universal-in-universal'),
   },
 
   configs: {},
+}
+
+plugin.configs.architecture = {
+  plugins: {
+    '@kaliber': plugin,
+  },
+  rules: {
+    '@kaliber/no-restricted-layer-import': 'error',
+    '@kaliber/no-nested-component': ['warn', {
+      deny: [
+        { parent: 'Container*', child: 'Container*' },
+        { parent: 'Heading*', child: 'Heading*' },
+      ]
+    }],
+    '@kaliber/no-universal-in-universal': 'error',
+  },
 }
 
 module.exports = plugin

--- a/machinery/ast.js
+++ b/machinery/ast.js
@@ -3,6 +3,12 @@ module.exports = {
   getFunctionName,
   getJSXElementName, getParentJSXElement, getParentJSXElements,
   isRootJSXElement, hasParentsJSXElementsWithClassName, isInJSXBranch, isInExport,
+  isComponentName,
+}
+
+/** A component name starts with an uppercase letter (PascalCase) */
+function isComponentName(name) {
+  return Boolean(name) && name[0] === name[0].toUpperCase() && name[0] !== name[0].toLowerCase()
 }
 
 function getPropertyName(property) {

--- a/machinery/ast.js
+++ b/machinery/ast.js
@@ -1,7 +1,7 @@
 module.exports = {
   getPropertyName,
   getFunctionName,
-  getJSXElementName, getParentJSXElement,
+  getJSXElementName, getParentJSXElement, getParentJSXElements,
   isRootJSXElement, hasParentsJSXElementsWithClassName, isInJSXBranch, isInExport,
 }
 

--- a/machinery/filename.js
+++ b/machinery/filename.js
@@ -1,8 +1,8 @@
 const path = require('node:path')
 
 module.exports = {
-  isApp, isPage, isTemplate,
-  getBaseFilename,
+  isApp, isPage, isTemplate, isUniversal,
+  getBaseFilename, getLayer, findSrcRoot,
 }
 
 function isApp(context) {
@@ -28,4 +28,28 @@ function getBaseFilename(context) {
     const [name] = basename.split('.')
     return name.slice(0, 1).toUpperCase() + name.slice(1)
   } else return basename
+}
+
+function isUniversal(context) {
+  const filename = context.filename
+  return !!filename && filename.endsWith('.universal.js')
+}
+
+function getLayer(filePath) {
+  const srcRoot = findSrcRoot(filePath)
+  if (!srcRoot) return null
+
+  const relative = filePath.slice(srcRoot.length + 1)
+  const segments = relative.split(path.sep)
+  if (!segments.length) return null
+
+  if (segments[0] === 'features' && segments.length > 1) return 'features/' + segments[1]
+  return segments[0]
+}
+
+function findSrcRoot(filePath) {
+  const segments = filePath.split(path.sep)
+  const srcIndex = segments.lastIndexOf('src')
+  if (srcIndex === -1) return null
+  return segments.slice(0, srcIndex + 1).join(path.sep)
 }

--- a/machinery/filename.js
+++ b/machinery/filename.js
@@ -3,6 +3,7 @@ const path = require('node:path')
 module.exports = {
   isApp, isPage, isTemplate, isUniversal,
   getBaseFilename, getLayer, findSrcRoot,
+  getLayerFromImportPath, isSublayerOf, matchesLayerPattern,
 }
 
 function isApp(context) {
@@ -35,16 +36,45 @@ function isUniversal(context) {
   return !!filename && filename.endsWith('.universal.js')
 }
 
-function getLayer(filePath) {
+/** Get the architectural layer for a file path (relative to its src root) */
+function getLayer(filePath, sublayerParents = ['features']) {
   const srcRoot = findSrcRoot(filePath)
   if (!srcRoot) return null
 
   const relative = filePath.slice(srcRoot.length + 1)
   const segments = relative.split(path.sep)
-  if (!segments.length) return null
 
-  if (segments[0] === 'features' && segments.length > 1) return 'features/' + segments[1]
-  return segments[0]
+  return layerFromSegments(segments, sublayerParents)
+}
+
+/** Get the architectural layer for an import path like '/features/hero/Hero' */
+function getLayerFromImportPath(importPath, sublayerParents = ['features']) {
+  const segments = importPath.slice(1).split('/')
+
+  return layerFromSegments(segments, sublayerParents)
+}
+
+/** Check if a layer is a sublayer of a parent (e.g. 'features/hero' is a sublayer of 'features') */
+function isSublayerOf(layer, parent) {
+  return layer.startsWith(parent + '/')
+}
+
+/**
+ * Check if a layer matches an allowed pattern, considering sublayer parents.
+ *
+ * - Exact match: 'machinery' matches 'machinery'
+ * - Parent match: 'features' matches 'features/hero' (when 'features' is a sublayer parent)
+ * - Wildcard match: 'features/*' matches 'features/hero'
+ */
+function matchesLayerPattern(targetLayer, pattern, sublayerParents = []) {
+  if (pattern === targetLayer) return true
+
+  for (const parent of sublayerParents) {
+    if (pattern === parent && isSublayerOf(targetLayer, parent)) return true
+    if (pattern === parent + '/*' && isSublayerOf(targetLayer, parent)) return true
+  }
+
+  return false
 }
 
 function findSrcRoot(filePath) {
@@ -52,4 +82,16 @@ function findSrcRoot(filePath) {
   const srcIndex = segments.lastIndexOf('src')
   if (srcIndex === -1) return null
   return segments.slice(0, srcIndex + 1).join(path.sep)
+}
+
+// ─── internal ───────────────────────────────────────────────────────────────
+
+function layerFromSegments(segments, sublayerParents) {
+  if (!segments.length || !segments[0]) return null
+
+  if (sublayerParents.includes(segments[0]) && segments.length > 1) {
+    return segments[0] + '/' + segments[1]
+  }
+
+  return segments[0]
 }

--- a/machinery/importGraph.js
+++ b/machinery/importGraph.js
@@ -1,0 +1,93 @@
+const { readFileSync, existsSync } = require('node:fs')
+const { join } = require('node:path')
+
+module.exports = { getImportGraph, _resetCache }
+
+let cached = null
+let cachedRoot = null
+
+/**
+ * Read the import graph from @kaliber/build's esbuild metafile.
+ *
+ * The metafile is written to `.kaliber-build/server-metafile.json` during
+ * build and (with a small @kaliber/build change) during watch mode.
+ *
+ * Returns null if no metafile exists yet (build hasn't run).
+ *
+ * @param {string} projectRoot
+ * @returns {{ transitiveDeps: (filePath: string) => Set<string>, findChain: (source: string, target: string) => string[] | null } | null}
+ */
+function getImportGraph(projectRoot) {
+  if (cached && cachedRoot === projectRoot) return cached
+
+  const metafilePath = join(projectRoot, '.kaliber-build', 'server-metafile.json')
+  if (!existsSync(metafilePath)) return null
+
+  try {
+    const metafile = JSON.parse(readFileSync(metafilePath, 'utf-8'))
+    cached = parseMetafile(metafile)
+    cachedRoot = projectRoot
+    return cached
+  } catch {
+    return null
+  }
+}
+
+/** @param {object} metafile — esbuild metafile with `inputs` */
+function parseMetafile(metafile) {
+  /** @type {Map<string, Set<string>>} filePath → direct dependencies */
+  const graph = new Map()
+
+  for (const [filePath, info] of Object.entries(metafile.inputs || {})) {
+    const deps = new Set()
+    for (const imp of info.imports || []) {
+      if (imp.path && !imp.external) deps.add(imp.path)
+    }
+    graph.set(filePath, deps)
+  }
+
+  return { transitiveDeps, findChain }
+
+  /** Get ALL transitive dependencies of a file (BFS) */
+  function transitiveDeps(filePath) {
+    const visited = new Set()
+    const queue = [filePath]
+
+    while (queue.length) {
+      const current = queue.pop()
+      if (visited.has(current)) continue
+      visited.add(current)
+      for (const dep of (graph.get(current) || [])) queue.push(dep)
+    }
+
+    visited.delete(filePath)
+    return visited
+  }
+
+  /** Find the shortest import chain from source to target (BFS) */
+  function findChain(source, target) {
+    const queue = [[source]]
+    const visited = new Set([source])
+
+    while (queue.length) {
+      const path = queue.shift()
+      const current = path[path.length - 1]
+
+      for (const dep of (graph.get(current) || [])) {
+        if (dep === target) return [...path, dep]
+        if (!visited.has(dep)) {
+          visited.add(dep)
+          queue.push([...path, dep])
+        }
+      }
+    }
+
+    return null
+  }
+}
+
+/** Reset the module-level cache — used in tests */
+function _resetCache() {
+  cached = null
+  cachedRoot = null
+}

--- a/machinery/importGraph.test.js
+++ b/machinery/importGraph.test.js
@@ -1,0 +1,532 @@
+const { describe, it, afterEach } = require('node:test')
+const assert = require('node:assert')
+const { writeFileSync, mkdirSync, rmSync } = require('node:fs')
+const { join } = require('node:path')
+const { getImportGraph, _resetCache } = require('./importGraph')
+
+const fixtureRoot = join(__dirname, '..', '.test-fixtures', 'import-graph')
+
+afterEach(() => {
+  _resetCache()
+  try { rmSync(fixtureRoot, { recursive: true, force: true }) } catch {}
+})
+
+// ─── getImportGraph ─────────────────────────────────────────────────────────
+
+describe('getImportGraph', () => {
+  it('returns null when no metafile exists', () => {
+    assert.strictEqual(getImportGraph('/nonexistent/path'), null)
+  })
+
+  it('returns null when metafile is malformed JSON', () => {
+    writeFile(fixtureRoot, 'not valid json {{{')
+    assert.strictEqual(getImportGraph(fixtureRoot), null)
+  })
+
+  it('returns a graph when metafile exists', () => {
+    writeMetafile(fixtureRoot, {
+      inputs: {
+        'src/a.js': { imports: [{ path: 'src/b.js' }] },
+        'src/b.js': { imports: [] },
+      },
+    })
+    const graph = getImportGraph(fixtureRoot)
+    assert.notStrictEqual(graph, null)
+  })
+
+  it('returns cached result for same project root', () => {
+    writeMetafile(fixtureRoot, {
+      inputs: {
+        'src/a.js': { imports: [{ path: 'src/b.js' }] },
+        'src/b.js': { imports: [] },
+      },
+    })
+    const graph1 = getImportGraph(fixtureRoot)
+    const graph2 = getImportGraph(fixtureRoot)
+    assert.strictEqual(graph1, graph2) // same object reference
+  })
+
+  it('re-reads when project root changes', () => {
+    const root2 = join(fixtureRoot, 'project2')
+    writeMetafile(fixtureRoot, {
+      inputs: {
+        'src/a.js': { imports: [{ path: 'src/b.js' }] },
+        'src/b.js': { imports: [] },
+      },
+    })
+    writeMetafile(root2, {
+      inputs: {
+        'src/x.js': { imports: [] },
+      },
+    })
+
+    const graph1 = getImportGraph(fixtureRoot)
+    const graph2 = getImportGraph(root2)
+    assert.notStrictEqual(graph1, graph2) // different objects
+  })
+
+  it('handles empty inputs', () => {
+    writeMetafile(fixtureRoot, { inputs: {} })
+    const graph = getImportGraph(fixtureRoot)
+    assert.notStrictEqual(graph, null)
+    assert.strictEqual(graph.transitiveDeps('anything').size, 0)
+  })
+
+  it('handles missing inputs key gracefully', () => {
+    writeMetafile(fixtureRoot, { outputs: {} })
+    const graph = getImportGraph(fixtureRoot)
+    assert.notStrictEqual(graph, null)
+    assert.strictEqual(graph.transitiveDeps('anything').size, 0)
+  })
+})
+
+// ─── transitiveDeps ─────────────────────────────────────────────────────────
+
+describe('transitiveDeps', () => {
+  it('returns direct dependencies', () => {
+    writeMetafile(fixtureRoot, {
+      inputs: {
+        'a.js': { imports: [{ path: 'b.js' }, { path: 'c.js' }] },
+        'b.js': { imports: [] },
+        'c.js': { imports: [] },
+      },
+    })
+    const graph = getImportGraph(fixtureRoot)
+    const deps = graph.transitiveDeps('a.js')
+
+    assert.strictEqual(deps.size, 2)
+    assert.ok(deps.has('b.js'))
+    assert.ok(deps.has('c.js'))
+  })
+
+  it('returns transitive dependencies through multiple hops', () => {
+    writeMetafile(fixtureRoot, {
+      inputs: {
+        'a.js': { imports: [{ path: 'b.js' }] },
+        'b.js': { imports: [{ path: 'c.js' }] },
+        'c.js': { imports: [{ path: 'd.js' }] },
+        'd.js': { imports: [] },
+      },
+    })
+    const graph = getImportGraph(fixtureRoot)
+    const deps = graph.transitiveDeps('a.js')
+
+    assert.strictEqual(deps.size, 3)
+    assert.ok(deps.has('b.js'))
+    assert.ok(deps.has('c.js'))
+    assert.ok(deps.has('d.js'))
+  })
+
+  it('does not include the source file itself', () => {
+    writeMetafile(fixtureRoot, {
+      inputs: {
+        'a.js': { imports: [{ path: 'b.js' }] },
+        'b.js': { imports: [] },
+      },
+    })
+    const graph = getImportGraph(fixtureRoot)
+    const deps = graph.transitiveDeps('a.js')
+
+    assert.ok(!deps.has('a.js'))
+  })
+
+  it('handles circular dependencies without infinite loop', () => {
+    writeMetafile(fixtureRoot, {
+      inputs: {
+        'a.js': { imports: [{ path: 'b.js' }] },
+        'b.js': { imports: [{ path: 'c.js' }] },
+        'c.js': { imports: [{ path: 'a.js' }] }, // cycle back
+      },
+    })
+    const graph = getImportGraph(fixtureRoot)
+    const deps = graph.transitiveDeps('a.js')
+
+    // Should include b, c but not a itself
+    assert.strictEqual(deps.size, 2)
+    assert.ok(deps.has('b.js'))
+    assert.ok(deps.has('c.js'))
+    assert.ok(!deps.has('a.js'))
+  })
+
+  it('handles self-referencing imports', () => {
+    writeMetafile(fixtureRoot, {
+      inputs: {
+        'a.js': { imports: [{ path: 'a.js' }] }, // imports itself
+      },
+    })
+    const graph = getImportGraph(fixtureRoot)
+    const deps = graph.transitiveDeps('a.js')
+
+    assert.strictEqual(deps.size, 0) // self not counted
+  })
+
+  it('handles diamond dependencies (A → B → D, A → C → D)', () => {
+    writeMetafile(fixtureRoot, {
+      inputs: {
+        'a.js': { imports: [{ path: 'b.js' }, { path: 'c.js' }] },
+        'b.js': { imports: [{ path: 'd.js' }] },
+        'c.js': { imports: [{ path: 'd.js' }] },
+        'd.js': { imports: [] },
+      },
+    })
+    const graph = getImportGraph(fixtureRoot)
+    const deps = graph.transitiveDeps('a.js')
+
+    // d.js should appear only once
+    assert.strictEqual(deps.size, 3)
+    assert.ok(deps.has('b.js'))
+    assert.ok(deps.has('c.js'))
+    assert.ok(deps.has('d.js'))
+  })
+
+  it('skips external imports', () => {
+    writeMetafile(fixtureRoot, {
+      inputs: {
+        'a.js': { imports: [
+          { path: 'b.js' },
+          { path: 'react', external: true },
+        ] },
+        'b.js': { imports: [] },
+      },
+    })
+    const graph = getImportGraph(fixtureRoot)
+    const deps = graph.transitiveDeps('a.js')
+
+    assert.strictEqual(deps.size, 1)
+    assert.ok(deps.has('b.js'))
+    assert.ok(!deps.has('react'))
+  })
+
+  it('returns empty set for unknown files', () => {
+    writeMetafile(fixtureRoot, {
+      inputs: { 'a.js': { imports: [] } },
+    })
+    const graph = getImportGraph(fixtureRoot)
+    const deps = graph.transitiveDeps('unknown.js')
+
+    assert.strictEqual(deps.size, 0)
+  })
+
+  it('handles deep chains (5+ levels)', () => {
+    writeMetafile(fixtureRoot, {
+      inputs: {
+        'a.js': { imports: [{ path: 'b.js' }] },
+        'b.js': { imports: [{ path: 'c.js' }] },
+        'c.js': { imports: [{ path: 'd.js' }] },
+        'd.js': { imports: [{ path: 'e.js' }] },
+        'e.js': { imports: [{ path: 'f.js' }] },
+        'f.js': { imports: [] },
+      },
+    })
+    const graph = getImportGraph(fixtureRoot)
+    const deps = graph.transitiveDeps('a.js')
+
+    assert.strictEqual(deps.size, 5)
+    assert.ok(deps.has('f.js'))
+  })
+
+  it('handles multiple independent import trees', () => {
+    writeMetafile(fixtureRoot, {
+      inputs: {
+        'a.js': { imports: [{ path: 'b.js' }] },
+        'b.js': { imports: [] },
+        'x.js': { imports: [{ path: 'y.js' }] },
+        'y.js': { imports: [] },
+      },
+    })
+    const graph = getImportGraph(fixtureRoot)
+
+    const depsA = graph.transitiveDeps('a.js')
+    assert.ok(depsA.has('b.js'))
+    assert.ok(!depsA.has('x.js'))
+    assert.ok(!depsA.has('y.js'))
+
+    const depsX = graph.transitiveDeps('x.js')
+    assert.ok(depsX.has('y.js'))
+    assert.ok(!depsX.has('a.js'))
+    assert.ok(!depsX.has('b.js'))
+  })
+})
+
+// ─── findChain ──────────────────────────────────────────────────────────────
+
+describe('findChain', () => {
+  it('finds a direct chain (1 hop)', () => {
+    writeMetafile(fixtureRoot, {
+      inputs: {
+        'a.js': { imports: [{ path: 'b.js' }] },
+        'b.js': { imports: [] },
+      },
+    })
+    const graph = getImportGraph(fixtureRoot)
+    const chain = graph.findChain('a.js', 'b.js')
+
+    assert.deepStrictEqual(chain, ['a.js', 'b.js'])
+  })
+
+  it('finds a transitive chain (2 hops)', () => {
+    writeMetafile(fixtureRoot, {
+      inputs: {
+        'a.js': { imports: [{ path: 'b.js' }] },
+        'b.js': { imports: [{ path: 'c.js' }] },
+        'c.js': { imports: [] },
+      },
+    })
+    const graph = getImportGraph(fixtureRoot)
+    const chain = graph.findChain('a.js', 'c.js')
+
+    assert.deepStrictEqual(chain, ['a.js', 'b.js', 'c.js'])
+  })
+
+  it('finds the shortest chain in a diamond', () => {
+    writeMetafile(fixtureRoot, {
+      inputs: {
+        'a.js': { imports: [{ path: 'b.js' }, { path: 'd.js' }] }, // direct to d!
+        'b.js': { imports: [{ path: 'c.js' }] },
+        'c.js': { imports: [{ path: 'd.js' }] },
+        'd.js': { imports: [] },
+      },
+    })
+    const graph = getImportGraph(fixtureRoot)
+    const chain = graph.findChain('a.js', 'd.js')
+
+    // Should be [a, d] not [a, b, c, d]
+    assert.deepStrictEqual(chain, ['a.js', 'd.js'])
+  })
+
+  it('returns null when no path exists', () => {
+    writeMetafile(fixtureRoot, {
+      inputs: {
+        'a.js': { imports: [{ path: 'b.js' }] },
+        'b.js': { imports: [] },
+        'c.js': { imports: [] }, // not reachable from a
+      },
+    })
+    const graph = getImportGraph(fixtureRoot)
+    const chain = graph.findChain('a.js', 'c.js')
+
+    assert.strictEqual(chain, null)
+  })
+
+  it('returns null for unknown source', () => {
+    writeMetafile(fixtureRoot, {
+      inputs: { 'a.js': { imports: [] } },
+    })
+    const graph = getImportGraph(fixtureRoot)
+    const chain = graph.findChain('unknown.js', 'a.js')
+
+    assert.strictEqual(chain, null)
+  })
+
+  it('handles circular dependencies in chain search', () => {
+    writeMetafile(fixtureRoot, {
+      inputs: {
+        'a.js': { imports: [{ path: 'b.js' }] },
+        'b.js': { imports: [{ path: 'c.js' }] },
+        'c.js': { imports: [{ path: 'a.js' }, { path: 'd.js' }] },
+        'd.js': { imports: [] },
+      },
+    })
+    const graph = getImportGraph(fixtureRoot)
+    const chain = graph.findChain('a.js', 'd.js')
+
+    assert.deepStrictEqual(chain, ['a.js', 'b.js', 'c.js', 'd.js'])
+  })
+
+  it('finds chain through a deep path (5 hops)', () => {
+    writeMetafile(fixtureRoot, {
+      inputs: {
+        'a.js': { imports: [{ path: 'b.js' }] },
+        'b.js': { imports: [{ path: 'c.js' }] },
+        'c.js': { imports: [{ path: 'd.js' }] },
+        'd.js': { imports: [{ path: 'e.js' }] },
+        'e.js': { imports: [{ path: 'f.js' }] },
+        'f.js': { imports: [] },
+      },
+    })
+    const graph = getImportGraph(fixtureRoot)
+    const chain = graph.findChain('a.js', 'f.js')
+
+    assert.deepStrictEqual(chain, ['a.js', 'b.js', 'c.js', 'd.js', 'e.js', 'f.js'])
+  })
+})
+
+// ─── .universal.js–specific scenarios ────────────────────────────────────────
+
+describe('universal nesting detection patterns', () => {
+  it('detects A.universal → Wrapper → B.universal', () => {
+    writeMetafile(fixtureRoot, {
+      inputs: {
+        'src/features/Outer.universal.js': {
+          imports: [{ path: 'src/features/Wrapper.js' }],
+        },
+        'src/features/Wrapper.js': {
+          imports: [{ path: 'src/features/Inner.universal.js' }],
+        },
+        'src/features/Inner.universal.js': { imports: [] },
+      },
+    })
+    const graph = getImportGraph(fixtureRoot)
+    const deps = graph.transitiveDeps('src/features/Outer.universal.js')
+    const universalDeps = [...deps].filter(d => d.endsWith('.universal.js'))
+
+    assert.strictEqual(universalDeps.length, 1)
+    assert.strictEqual(universalDeps[0], 'src/features/Inner.universal.js')
+
+    const chain = graph.findChain(
+      'src/features/Outer.universal.js',
+      'src/features/Inner.universal.js'
+    )
+    assert.deepStrictEqual(chain, [
+      'src/features/Outer.universal.js',
+      'src/features/Wrapper.js',
+      'src/features/Inner.universal.js',
+    ])
+  })
+
+  it('detects through multiple intermediate files', () => {
+    writeMetafile(fixtureRoot, {
+      inputs: {
+        'src/A.universal.js': { imports: [{ path: 'src/B.js' }] },
+        'src/B.js': { imports: [{ path: 'src/C.js' }] },
+        'src/C.js': { imports: [{ path: 'src/D.universal.js' }] },
+        'src/D.universal.js': { imports: [] },
+      },
+    })
+    const graph = getImportGraph(fixtureRoot)
+    const deps = graph.transitiveDeps('src/A.universal.js')
+    const universalDeps = [...deps].filter(d => d.endsWith('.universal.js'))
+
+    assert.strictEqual(universalDeps.length, 1)
+    assert.strictEqual(universalDeps[0], 'src/D.universal.js')
+  })
+
+  it('detects multiple transitive universal deps from one file', () => {
+    writeMetafile(fixtureRoot, {
+      inputs: {
+        'src/Page.universal.js': {
+          imports: [{ path: 'src/Layout.js' }, { path: 'src/Sidebar.js' }],
+        },
+        'src/Layout.js': { imports: [{ path: 'src/Header.universal.js' }] },
+        'src/Sidebar.js': { imports: [{ path: 'src/Widget.universal.js' }] },
+        'src/Header.universal.js': { imports: [] },
+        'src/Widget.universal.js': { imports: [] },
+      },
+    })
+    const graph = getImportGraph(fixtureRoot)
+    const deps = graph.transitiveDeps('src/Page.universal.js')
+    const universalDeps = [...deps].filter(d => d.endsWith('.universal.js'))
+
+    assert.strictEqual(universalDeps.length, 2)
+    assert.ok(universalDeps.includes('src/Header.universal.js'))
+    assert.ok(universalDeps.includes('src/Widget.universal.js'))
+  })
+
+  it('does not flag universal deps from non-universal files', () => {
+    writeMetafile(fixtureRoot, {
+      inputs: {
+        'src/pages/Home.js': { // not .universal.js!
+          imports: [{ path: 'src/features/Menu.universal.js' }],
+        },
+        'src/features/Menu.universal.js': { imports: [] },
+      },
+    })
+    const graph = getImportGraph(fixtureRoot)
+    // This is fine — Home.js is not a universal file
+    const deps = graph.transitiveDeps('src/pages/Home.js')
+    assert.ok(deps.has('src/features/Menu.universal.js'))
+    // The rule itself skips non-.universal.js files, not the graph
+  })
+
+  it('handles realistic Kaliber project structure', () => {
+    writeMetafile(fixtureRoot, {
+      inputs: {
+        'src/pages/Home.js': {
+          imports: [
+            { path: 'src/features/hero/Hero.universal.js' },
+            { path: 'src/features/navigation/Navigation.universal.js' },
+          ],
+        },
+        'src/features/hero/Hero.universal.js': {
+          imports: [
+            { path: 'src/features/buildingBlocks/Button.js' },
+            { path: 'src/machinery/I18n.js' },
+          ],
+        },
+        'src/features/navigation/Navigation.universal.js': {
+          imports: [
+            { path: 'src/features/buildingBlocks/Link.js' },
+            { path: 'src/machinery/I18n.js' },
+          ],
+        },
+        'src/features/buildingBlocks/Button.js': {
+          imports: [{ path: 'src/machinery/I18n.js' }],
+        },
+        'src/features/buildingBlocks/Link.js': {
+          imports: [{ path: 'src/machinery/I18n.js' }],
+        },
+        'src/machinery/I18n.js': { imports: [] },
+      },
+    })
+    const graph = getImportGraph(fixtureRoot)
+
+    // Hero.universal.js should not have any universal deps
+    const heroDeps = graph.transitiveDeps('src/features/hero/Hero.universal.js')
+    const heroUniversalDeps = [...heroDeps].filter(d => d.endsWith('.universal.js'))
+    assert.strictEqual(heroUniversalDeps.length, 0)
+
+    // Page is not universal, so it can import universals
+    const pageDeps = graph.transitiveDeps('src/pages/Home.js')
+    const pageUniversalDeps = [...pageDeps].filter(d => d.endsWith('.universal.js'))
+    assert.strictEqual(pageUniversalDeps.length, 2)
+  })
+
+  it('detects sneaky nesting via shared buildingBlocks', () => {
+    // The problematic pattern: a universal component uses a buildingBlock
+    // that internally renders another universal component
+    writeMetafile(fixtureRoot, {
+      inputs: {
+        'src/features/Search.universal.js': {
+          imports: [{ path: 'src/features/buildingBlocks/SearchBar.js' }],
+        },
+        'src/features/buildingBlocks/SearchBar.js': {
+          imports: [{ path: 'src/features/suggestions/Suggestions.universal.js' }],
+        },
+        'src/features/suggestions/Suggestions.universal.js': {
+          imports: [{ path: 'src/machinery/hooks.js' }],
+        },
+        'src/machinery/hooks.js': { imports: [] },
+      },
+    })
+    const graph = getImportGraph(fixtureRoot)
+    const deps = graph.transitiveDeps('src/features/Search.universal.js')
+    const universalDeps = [...deps].filter(d => d.endsWith('.universal.js'))
+
+    assert.strictEqual(universalDeps.length, 1)
+    assert.strictEqual(universalDeps[0], 'src/features/suggestions/Suggestions.universal.js')
+
+    const chain = graph.findChain(
+      'src/features/Search.universal.js',
+      'src/features/suggestions/Suggestions.universal.js'
+    )
+    assert.deepStrictEqual(chain, [
+      'src/features/Search.universal.js',
+      'src/features/buildingBlocks/SearchBar.js',
+      'src/features/suggestions/Suggestions.universal.js',
+    ])
+  })
+})
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function writeMetafile(root, metafile) {
+  const dir = join(root, '.kaliber-build')
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'server-metafile.json'), JSON.stringify(metafile))
+}
+
+function writeFile(root, content) {
+  const dir = join(root, '.kaliber-build')
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'server-metafile.json'), content)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,4415 @@
+{
+  "name": "@kaliber/eslint-plugin",
+  "version": "2.1.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@kaliber/eslint-plugin",
+      "version": "2.1.1",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/eslint-parser": "^7.16.5",
+        "@babel/preset-react": "^7.26.3",
+        "@eslint/compat": "^2.1.0",
+        "@eslint/js": "^9.39.4",
+        "@stylistic/eslint-plugin": "^5.10.0",
+        "eslint": "^9.39.4",
+        "eslint-import-resolver-node": "^0.4.0",
+        "eslint-plugin-import-x": "^4.0.0",
+        "eslint-plugin-jsx-a11y": "^6.10.0",
+        "eslint-plugin-react": "^7.37.0",
+        "eslint-plugin-react-hooks": "^7.1.1",
+        "jsx-ast-utils": "^3.3.5",
+        "prop-types": "^15.8.1"
+      },
+      "bin": {
+        "kaliber-eslint-migrate": "bin/migrate-to-flat-config.js"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/eslint-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.29.7.tgz",
+      "integrity": "sha512-zxt+UJTOMKvUt3yOg+D58MLuz334pHp93qifMFcjIIO+9hN6t+ufw2gi7vDPMpxvfnHRR+3VVXvIjineCcgyXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
+        "eslint-visitor-keys": "^2.1.0",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0",
+        "eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
+      "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-display-name": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.29.7.tgz",
+      "integrity": "sha512-+1wdDMGNb4UPeY3Q4L5yLiYe6TXPXubs4NjrgRFw13hPRLJfEMw2Q5OXkee6/IfdqePIeW4Jjwe3aBh7SdKz4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.29.7.tgz",
+      "integrity": "sha512-WsZulLVBUHXVj2cUcPVx6UE21TpalB6bHbSFErKT0Ib++ax24jjXe73FqlWvdylFOjiuPHYi6VCcgRad1ItN+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-syntax-jsx": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-development": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.29.7.tgz",
+      "integrity": "sha512-Xfy3UVMF04+ypnFbkhvfqtmvwfe92qwQdbGZVonhE+6v35GzlofmOnA1szaZqzb9xYWr0nl1e5EMmzi0DNON1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-react-jsx": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-pure-annotations": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.29.7.tgz",
+      "integrity": "sha512-H5E+HBgDpr6Q5t+Aj11tL7XkIui1jhbIoArVQnqjgXo5/3YxkN7ZEBcWF4RQlB0T4rrxJQbXS6kiFV6B7XTqUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-react": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.29.7.tgz",
+      "integrity": "sha512-C+PV1TFUPTmBQGoPBL8j2QmLpZ117YTCwxIZeJOM96GbYMFSc7/pOXU5lVykwnZxyTqQxRsvoRk6f2FktZgGHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "@babel/plugin-transform-react-display-name": "^7.29.7",
+        "@babel/plugin-transform-react-jsx": "^7.29.7",
+        "@babel/plugin-transform-react-jsx-development": "^7.29.7",
+        "@babel/plugin-transform-react-pure-annotations": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/compat": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-2.1.0.tgz",
+      "integrity": "sha512-LgaSCymEpw7tF53xvDw9SNsraPb1IBHxpdABIOM0hW8UAlP8znrjYtuxfR58FSJ3L9BhwD+FaPRFQpZq84Nh6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "peerDependencies": {
+        "eslint": "^8.40 || 9 || 10"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers/node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
+      "version": "5.1.1-v1",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
+      "integrity": "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==",
+      "license": "MIT",
+      "dependencies": {
+        "eslint-scope": "5.1.1"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
+      "integrity": "sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/types": "^8.56.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "estraverse": "^5.3.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": "^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
+      "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
+      "integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
+      "integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
+      "integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
+      "integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
+      "integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+      "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+      "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
+      "integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
+      "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
+      "integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
+      "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
+      "integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
+      "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
+      "integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
+      "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
+      "integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
+      "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-openharmony-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
+      "integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
+      "integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
+      "integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
+      "integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
+      "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "license": "MIT"
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.38",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/comment-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.7.tgz",
+      "integrity": "sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "license": "MIT"
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.378",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.378.tgz",
+      "integrity": "sha512-VinvOAuuPmdD1guEgGv5f2Qp7/vlfqOrUOMYNnOD4wj3pit8kRsQHzfIf6teyUGWo15Tg5+bOJaRunvyltpVWQ==",
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/es-abstract": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-abstract-get": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+      "integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.2",
+        "is-callable": "^1.2.7",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.3.tgz",
+      "integrity": "sha512-0PuBxFi+4uPanB97iDxCLWuHeYud2FALrw5HFZGtAF38UpJDbDC8frwp2cnDyae692CQ0dou60UwWfhgsa4U/g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.1.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.3.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.5",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.1.tgz",
+      "integrity": "sha512-CxN9N56HYfd2m/acc/NOFrZQsN9kU4eh+2kk6A707Kz1krH8tKmfrs5RnftB8WNX80T0NS7vSQsDOlg23diR2g==",
+      "license": "MIT",
+      "dependencies": {
+        "es-abstract-get": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.1.0",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-import-context": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
+      "integrity": "sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "get-tsconfig": "^4.10.1",
+        "stable-hash-x": "^0.2.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-context"
+      },
+      "peerDependencies": {
+        "unrs-resolver": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "unrs-resolver": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.4.0.tgz",
+      "integrity": "sha512-wV22NewD4lwrMp94THds3/MjW7qPYupLj3wxLZCYkKrSLfVslRS/7lcbogiEwn9oT4cunDDCsTiBo/V16WlEUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.16.2",
+        "resolve": "^2.0.0-next.7"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import-x": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.17.0.tgz",
+      "integrity": "sha512-aM7V25Bg6YuYxtEhwjafzfS0NTMds1D2PMQI0K4KqJxQJRtkP4CO+MQTWRdBq2qAnmPxTxLevhXUBtByxJqS1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "^8.56.0",
+        "comment-parser": "^1.4.1",
+        "debug": "^4.4.1",
+        "eslint-import-context": "^0.1.9",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.3 || ^10.1.2",
+        "semver": "^7.7.2",
+        "stable-hash-x": "^0.2.0",
+        "unrs-resolver": "^1.9.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-import-x"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/utils": "^8.56.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "eslint-import-resolver-node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/utils": {
+          "optional": true
+        },
+        "eslint-import-resolver-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/eslint-scope/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "license": "ISC"
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
+      "integrity": "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2",
+        "hasown": "^2.0.4",
+        "is-callable": "^1.2.7",
+        "is-document.all": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-document.all": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
+      "integrity": "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "license": "MIT"
+    },
+    "node_modules/node-exports-info": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.2.tgz",
+      "integrity": "sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==",
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.flatmap": "^1.3.3",
+        "es-errors": "^1.3.0",
+        "object.entries": "^1.1.9",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "2.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.2",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/stable-hash-x": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
+      "integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+      "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-object-atoms": "^1.1.2",
+        "has-property-descriptors": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+      "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+      "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "for-each": "^0.3.5",
+        "gopd": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "possible-typed-array-names": "^1.1.0",
+        "reflect.getprototypeof": "^1.0.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
+      "integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.4"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.12.2",
+        "@unrs/resolver-binding-android-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-x64": "1.12.2",
+        "@unrs/resolver-binding-freebsd-x64": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-musl": "1.12.2",
+        "@unrs/resolver-binding-openharmony-arm64": "1.12.2",
+        "@unrs/resolver-binding-wasm32-wasi": "1.12.2",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    }
+  }
+}

--- a/rules/no-nested-component/index.js
+++ b/rules/no-nested-component/index.js
@@ -1,0 +1,82 @@
+const { getJSXElementName, getParentJSXElements } = require('../../machinery/ast')
+const docsUrl = require('../../machinery/docsUrl')
+
+const defaultDeny = [
+  { parent: 'Container*', child: 'Container*' },
+  { parent: 'Heading*', child: 'Heading*' },
+]
+
+const messages = {
+  'nested component': (child, parent) =>
+    `Unexpected '${child}' nested inside '${parent}' — these components must not be nested`,
+}
+
+module.exports = {
+  messages,
+
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Prevent specific React components from being nested inside each other',
+      url: docsUrl(__dirname),
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          deny: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                parent: { type: 'string' },
+                child: { type: 'string' },
+              },
+              required: ['parent', 'child'],
+              additionalProperties: false,
+            },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+
+  create(context) {
+    const options = context.options[0] || {}
+    const deny = options.deny || defaultDeny
+
+    return {
+      JSXOpeningElement(node) {
+        const jsxElement = node.parent
+        const name = getJSXElementName(jsxElement)
+
+        if (name[0] !== name[0].toUpperCase()) return
+
+        const matchingRules = deny.filter(x => matches(name, x.child))
+        if (!matchingRules.length) return
+
+        const ancestors = getParentJSXElements(jsxElement)
+        for (const ancestor of ancestors) {
+          const ancestorName = getJSXElementName(ancestor)
+          if (ancestorName[0] !== ancestorName[0].toUpperCase()) continue
+
+          for (const rule of matchingRules) {
+            if (matches(ancestorName, rule.parent)) {
+              context.report({
+                message: messages['nested component'](name, ancestorName),
+                node,
+              })
+              return
+            }
+          }
+        }
+      },
+    }
+  },
+}
+
+function matches(name, pattern) {
+  if (pattern.endsWith('*')) return name.startsWith(pattern.slice(0, -1))
+  return name === pattern
+}

--- a/rules/no-nested-component/index.js
+++ b/rules/no-nested-component/index.js
@@ -1,4 +1,4 @@
-const { getJSXElementName, getParentJSXElements } = require('../../machinery/ast')
+const { getJSXElementName, getParentJSXElements, isComponentName } = require('../../machinery/ast')
 const docsUrl = require('../../machinery/docsUrl')
 
 const defaultDeny = [
@@ -51,7 +51,7 @@ module.exports = {
         const jsxElement = node.parent
         const name = getJSXElementName(jsxElement)
 
-        if (name[0] !== name[0].toUpperCase()) return
+        if (!isComponentName(name)) return
 
         const matchingRules = deny.filter(x => matches(name, x.child))
         if (!matchingRules.length) return
@@ -59,7 +59,7 @@ module.exports = {
         const ancestors = getParentJSXElements(jsxElement)
         for (const ancestor of ancestors) {
           const ancestorName = getJSXElementName(ancestor)
-          if (ancestorName[0] !== ancestorName[0].toUpperCase()) continue
+          if (!isComponentName(ancestorName)) continue
 
           for (const rule of matchingRules) {
             if (matches(ancestorName, rule.parent)) {

--- a/rules/no-nested-component/readme.md
+++ b/rules/no-nested-component/readme.md
@@ -1,0 +1,67 @@
+# no-nested-component
+
+Prevent specific React components from being nested inside each other in the same file's JSX tree.
+
+## Rule Details
+
+This rule catches cases where components that shouldn't be nested end up inside each other — even with intermediate native elements between them.
+
+### ❌ Invalid
+
+```jsx
+// Container inside Container
+<ContainerLg>
+  <ContainerSm>
+    <p>content</p>
+  </ContainerSm>
+</ContainerLg>
+
+// Still invalid — intermediate elements don't help
+<ContainerXxl>
+  <div>
+    <ContainerLg>
+      <div />
+    </ContainerLg>
+  </div>
+</ContainerXxl>
+
+// Heading inside Heading
+<HeadingXl h={1} title="A">
+  <HeadingMd h={2} title="B" />
+</HeadingXl>
+```
+
+### ✅ Valid
+
+```jsx
+// Different component types can nest freely
+<ContainerLg>
+  <HeadingXl h={1} title="Hello" />
+  <Button />
+</ContainerLg>
+
+// Unlisted components are not restricted
+<Foo><Bar /></Foo>
+```
+
+## Default Deny List
+
+| Parent | Child | Rationale |
+|--------|-------|-----------|
+| `Container*` | `Container*` | Containers add max-width + padding — nesting creates unintended narrowing |
+| `Heading*` | `Heading*` | Headings define document hierarchy — nesting breaks semantics |
+
+Patterns ending with `*` match any component name that starts with the prefix.
+
+## Options
+
+Override the default deny list:
+
+```js
+'@kaliber/no-nested-component': ['error', {
+  deny: [
+    { parent: 'Container*', child: 'Container*' },
+    { parent: 'Modal', child: 'Modal' },
+  ]
+}]
+```

--- a/rules/no-nested-component/test.js
+++ b/rules/no-nested-component/test.js
@@ -1,0 +1,35 @@
+const { messages } = require('./')
+const { test } = require('../../machinery/test')
+
+test('no-nested-component', {
+  valid: [
+    `<div><ContainerLg><div /></ContainerLg></div>`,
+    `<ContainerLg><Button /></ContainerLg>`,
+    `<div><HeadingXl h={1} title="Hello" /></div>`,
+    `<ContainerLg><HeadingXl h={1} title="Hello" /></ContainerLg>`,
+    `<Foo><Bar /></Foo>`,
+  ],
+  invalid: [
+    {
+      code: `<ContainerLg><ContainerSm><div /></ContainerSm></ContainerLg>`,
+      errors: [{ message: messages['nested component']('ContainerSm', 'ContainerLg') }],
+    },
+    {
+      code: `<ContainerXxl><div><ContainerLg><div /></ContainerLg></div></ContainerXxl>`,
+      errors: [{ message: messages['nested component']('ContainerLg', 'ContainerXxl') }],
+    },
+    {
+      code: `<ContainerLg><ContainerSm><p>content</p></ContainerSm></ContainerLg>`,
+      errors: [{ message: messages['nested component']('ContainerSm', 'ContainerLg') }],
+    },
+    {
+      code: `<HeadingXl h={1} title="A"><HeadingMd h={2} title="B" /></HeadingXl>`,
+      errors: [{ message: messages['nested component']('HeadingMd', 'HeadingXl') }],
+    },
+    {
+      code: `<Modal><Modal /></Modal>`,
+      options: [{ deny: [{ parent: 'Modal', child: 'Modal' }] }],
+      errors: [{ message: messages['nested component']('Modal', 'Modal') }],
+    },
+  ],
+})

--- a/rules/no-nested-component/test.js
+++ b/rules/no-nested-component/test.js
@@ -1,35 +1,139 @@
 const { messages } = require('./')
-const { test } = require('../../machinery/test')
+const { test, merge } = require('../../machinery/test')
 
-test('no-nested-component', {
-  valid: [
-    `<div><ContainerLg><div /></ContainerLg></div>`,
-    `<ContainerLg><Button /></ContainerLg>`,
-    `<div><HeadingXl h={1} title="Hello" /></div>`,
-    `<ContainerLg><HeadingXl h={1} title="Hello" /></ContainerLg>`,
-    `<Foo><Bar /></Foo>`,
-  ],
-  invalid: [
-    {
-      code: `<ContainerLg><ContainerSm><div /></ContainerSm></ContainerLg>`,
-      errors: [{ message: messages['nested component']('ContainerSm', 'ContainerLg') }],
-    },
-    {
-      code: `<ContainerXxl><div><ContainerLg><div /></ContainerLg></div></ContainerXxl>`,
-      errors: [{ message: messages['nested component']('ContainerLg', 'ContainerXxl') }],
-    },
-    {
-      code: `<ContainerLg><ContainerSm><p>content</p></ContainerSm></ContainerLg>`,
-      errors: [{ message: messages['nested component']('ContainerSm', 'ContainerLg') }],
-    },
-    {
-      code: `<HeadingXl h={1} title="A"><HeadingMd h={2} title="B" /></HeadingXl>`,
-      errors: [{ message: messages['nested component']('HeadingMd', 'HeadingXl') }],
-    },
-    {
-      code: `<Modal><Modal /></Modal>`,
-      options: [{ deny: [{ parent: 'Modal', child: 'Modal' }] }],
-      errors: [{ message: messages['nested component']('Modal', 'Modal') }],
-    },
-  ],
-})
+test('no-nested-component', merge(
+  // ─── Default deny list (Container*, Heading*) ─────────────────────────────
+  {
+    valid: [
+      // Native elements can nest freely
+      `<div><section><p /></section></div>`,
+
+      // Container with non-Container children
+      `<ContainerLg><Button /></ContainerLg>`,
+      `<ContainerLg><HeadingXl h={1} title="Hello" /></ContainerLg>`,
+      `<div><ContainerLg><div /></ContainerLg></div>`,
+
+      // Heading with non-Heading children
+      `<HeadingXl h={1} title="Hello"><span>sub</span></HeadingXl>`,
+      `<div><HeadingXl h={1} title="Hello" /></div>`,
+
+      // Unrelated components nest freely
+      `<Foo><Bar /></Foo>`,
+      `<Modal><Button /></Modal>`,
+      `<Layout><Sidebar><Menu /></Sidebar></Layout>`,
+
+      // Lowercase elements never flagged
+      `<container><container /></container>`,
+      `<heading><heading /></heading>`,
+
+      // Components starting with different prefix
+      `<ContentBlock><ContentSection /></ContentBlock>`,
+
+      // Fragment wrappers
+      `<ContainerLg><>{children}</></ContainerLg>`,
+    ],
+    invalid: [
+      // Container* nesting — direct child
+      {
+        code: `<ContainerLg><ContainerSm><div /></ContainerSm></ContainerLg>`,
+        errors: [{ message: messages['nested component']('ContainerSm', 'ContainerLg') }],
+      },
+      // Container* nesting — with intermediate native elements
+      {
+        code: `<ContainerXxl><div><ContainerLg><div /></ContainerLg></div></ContainerXxl>`,
+        errors: [{ message: messages['nested component']('ContainerLg', 'ContainerXxl') }],
+      },
+      // Container* nesting — same variant
+      {
+        code: `<ContainerLg><ContainerLg><div /></ContainerLg></ContainerLg>`,
+        errors: [{ message: messages['nested component']('ContainerLg', 'ContainerLg') }],
+      },
+      // Container* nesting — deeply nested
+      {
+        code: `<ContainerLg><div><section><article><ContainerSm><p /></ContainerSm></article></section></div></ContainerLg>`,
+        errors: [{ message: messages['nested component']('ContainerSm', 'ContainerLg') }],
+      },
+      // Container* nesting — FlexibleLg variant
+      {
+        code: `<ContainerFlexibleLg><ContainerMd><div /></ContainerMd></ContainerFlexibleLg>`,
+        errors: [{ message: messages['nested component']('ContainerMd', 'ContainerFlexibleLg') }],
+      },
+      // Heading* nesting
+      {
+        code: `<HeadingXl h={1} title="A"><HeadingMd h={2} title="B" /></HeadingXl>`,
+        errors: [{ message: messages['nested component']('HeadingMd', 'HeadingXl') }],
+      },
+      // Heading* nesting — same variant
+      {
+        code: `<HeadingLg h={1} title="A"><HeadingLg h={2} title="B" /></HeadingLg>`,
+        errors: [{ message: messages['nested component']('HeadingLg', 'HeadingLg') }],
+      },
+      // Heading* nesting — with intermediate elements
+      {
+        code: `<HeadingXxl h={1} title="A"><div><HeadingSm h={3} title="C" /></div></HeadingXxl>`,
+        errors: [{ message: messages['nested component']('HeadingSm', 'HeadingXxl') }],
+      },
+      // ContainerSm inside ContainerLg with content
+      {
+        code: `<ContainerLg><ContainerSm><p>content</p></ContainerSm></ContainerLg>`,
+        errors: [{ message: messages['nested component']('ContainerSm', 'ContainerLg') }],
+      },
+    ],
+  },
+
+  // ─── Custom deny list ─────────────────────────────────────────────────────
+  {
+    valid: [
+      // Default deny list is replaced — Container nesting is now allowed
+      {
+        code: `<ContainerLg><ContainerSm><div /></ContainerSm></ContainerLg>`,
+        options: [{ deny: [{ parent: 'Modal', child: 'Modal' }] }],
+      },
+      // Custom deny: Modal-Modal — different children are fine
+      {
+        code: `<Modal><Button /></Modal>`,
+        options: [{ deny: [{ parent: 'Modal', child: 'Modal' }] }],
+      },
+      // Custom deny: wildcard parent, specific child — non-matching child
+      {
+        code: `<Dropdown><Button /></Dropdown>`,
+        options: [{ deny: [{ parent: 'Dropdown*', child: 'Dropdown*' }] }],
+      },
+    ],
+    invalid: [
+      // Custom deny: exact match
+      {
+        code: `<Modal><Modal /></Modal>`,
+        options: [{ deny: [{ parent: 'Modal', child: 'Modal' }] }],
+        errors: [{ message: messages['nested component']('Modal', 'Modal') }],
+      },
+      // Custom deny: wildcard patterns
+      {
+        code: `<DropdownMenu><DropdownSubmenu /></DropdownMenu>`,
+        options: [{ deny: [{ parent: 'Dropdown*', child: 'Dropdown*' }] }],
+        errors: [{ message: messages['nested component']('DropdownSubmenu', 'DropdownMenu') }],
+      },
+      // Custom deny: multiple rules
+      {
+        code: `<Modal><Modal /></Modal>`,
+        options: [{ deny: [
+          { parent: 'Modal', child: 'Modal' },
+          { parent: 'Dialog', child: 'Dialog' },
+        ] }],
+        errors: [{ message: messages['nested component']('Modal', 'Modal') }],
+      },
+      // Custom deny: parent wildcard, child exact
+      {
+        code: `<AccordionItem><AccordionItem /></AccordionItem>`,
+        options: [{ deny: [{ parent: 'Accordion*', child: 'AccordionItem' }] }],
+        errors: [{ message: messages['nested component']('AccordionItem', 'AccordionItem') }],
+      },
+      // Custom deny: with intermediate elements
+      {
+        code: `<Modal><div><p><Modal /></p></div></Modal>`,
+        options: [{ deny: [{ parent: 'Modal', child: 'Modal' }] }],
+        errors: [{ message: messages['nested component']('Modal', 'Modal') }],
+      },
+    ],
+  },
+))

--- a/rules/no-restricted-layer-import/index.js
+++ b/rules/no-restricted-layer-import/index.js
@@ -1,5 +1,8 @@
 const docsUrl = require('../../machinery/docsUrl')
-const { getLayer, findSrcRoot } = require('../../machinery/filename')
+const {
+  getLayer, getLayerFromImportPath,
+  isSublayerOf, matchesLayerPattern,
+} = require('../../machinery/filename')
 
 const messages = {
   'restricted layer import': (importPath, sourceLayer, targetLayer) =>
@@ -43,7 +46,8 @@ module.exports = {
 
   create(context) {
     const options = context.options[0] || {}
-    const layers = options.layers || defaultLayers
+    const layers = buildLayers(options.layers)
+    const sublayerParents = getSublayerParents(layers)
 
     return {
       'ImportDeclaration': checkImport,
@@ -57,18 +61,18 @@ module.exports = {
       const importPath = source.value
       if (!importPath.startsWith('/')) return
 
-      const sourceLayer = getLayer(context.filename)
+      const sourceLayer = getLayer(context.filename, sublayerParents)
       if (!sourceLayer) return
 
-      const targetLayer = getLayerFromImportPath(importPath)
+      const targetLayer = getLayerFromImportPath(importPath, sublayerParents)
       if (!targetLayer) return
 
       if (sourceLayer === targetLayer) return
 
-      const allowList = findAllowList(layers, sourceLayer)
+      const allowList = findAllowList(layers, sourceLayer, sublayerParents)
       if (!allowList) return
 
-      if (isAllowed(allowList, targetLayer)) return
+      if (allowList.some(pattern => matchesLayerPattern(targetLayer, pattern, sublayerParents))) return
 
       context.report({
         message: messages['restricted layer import'](importPath, sourceLayer, targetLayer),
@@ -78,26 +82,44 @@ module.exports = {
   }
 }
 
-function getLayerFromImportPath(importPath) {
-  const withoutSlash = importPath.slice(1)
-  const segments = withoutSlash.split('/')
-  if (!segments.length || !segments[0]) return null
-
-  if (segments[0] === 'features' && segments.length > 1) return 'features/' + segments[1]
-  return segments[0]
+/**
+ * Extract sublayer parents from layer config.
+ * Any key like `foo/*` means `foo` is a sublayer parent.
+ */
+function getSublayerParents(layers) {
+  return Object.keys(layers)
+    .filter(key => key.endsWith('/*'))
+    .map(key => key.slice(0, -2))
 }
 
-function findAllowList(layers, sourceLayer) {
+function findAllowList(layers, sourceLayer, sublayerParents) {
   if (layers[sourceLayer]) return layers[sourceLayer]
-  if (sourceLayer.startsWith('features/') && layers['features/*']) return layers['features/*']
+
+  for (const parent of sublayerParents) {
+    if (isSublayerOf(sourceLayer, parent) && layers[parent + '/*']) {
+      return layers[parent + '/*']
+    }
+  }
+
   return null
 }
 
-function isAllowed(allowList, targetLayer) {
-  return allowList.some(allowed => {
-    if (allowed === targetLayer) return true
-    if (allowed === 'features' && targetLayer.startsWith('features/')) return true
-    if (allowed === 'features/*' && targetLayer.startsWith('features/')) return true
-    return false
-  })
+/**
+ * Builds the final layer map by merging:
+ * 1. Default layers as the base
+ * 2. Custom layers on top (adding new layers, extending existing ones)
+ * 3. sharedRootModules appended to every layer automatically
+ */
+function buildLayers(customLayers) {
+  if (!customLayers) return defaultLayers
+
+  const merged = { ...defaultLayers }
+
+  for (const [layer, allowList] of Object.entries(customLayers)) {
+    const base = merged[layer] || []
+    const combined = [...new Set([...base, ...allowList, ...sharedRootModules])]
+    merged[layer] = combined
+  }
+
+  return merged
 }

--- a/rules/no-restricted-layer-import/index.js
+++ b/rules/no-restricted-layer-import/index.js
@@ -1,0 +1,97 @@
+const docsUrl = require('../../machinery/docsUrl')
+const { getLayer, findSrcRoot } = require('../../machinery/filename')
+
+const messages = {
+  'restricted layer import': (importPath, sourceLayer, targetLayer) =>
+    `Unexpected import '${importPath}' — '${sourceLayer}' may not import from '${targetLayer}'`,
+}
+
+const defaultLayers = {
+  'features/buildingBlocks': ['features/buildingBlocks', 'machinery'],
+  'features/*': ['features/*', 'features/buildingBlocks', 'machinery'],
+  'machinery': ['machinery'],
+  'pages': ['pages', 'features', 'machinery', 'templates', 'wrappers'],
+  'templates': ['features', 'machinery'],
+  'wrappers': ['features', 'machinery'],
+}
+
+module.exports = {
+  messages,
+
+  meta: {
+    type: 'problem',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          layers: { type: 'object' },
+        },
+        additionalProperties: false,
+      },
+    ],
+    docs: {
+      description: 'Enforce architectural layer boundaries — prevent imports that cross forbidden layer boundaries',
+      url: docsUrl(__dirname),
+    },
+  },
+
+  create(context) {
+    const options = context.options[0] || {}
+    const layers = options.layers || defaultLayers
+
+    return {
+      'ImportDeclaration': checkImport,
+      'ExportNamedDeclaration': checkImport,
+      'ExportAllDeclaration': checkImport,
+    }
+
+    function checkImport({ source }) {
+      if (!source) return
+
+      const importPath = source.value
+      if (!importPath.startsWith('/')) return
+
+      const sourceLayer = getLayer(context.filename)
+      if (!sourceLayer) return
+
+      const targetLayer = getLayerFromImportPath(importPath)
+      if (!targetLayer) return
+
+      if (sourceLayer === targetLayer) return
+
+      const allowList = findAllowList(layers, sourceLayer)
+      if (!allowList) return
+
+      if (isAllowed(allowList, targetLayer)) return
+
+      context.report({
+        message: messages['restricted layer import'](importPath, sourceLayer, targetLayer),
+        node: source,
+      })
+    }
+  }
+}
+
+function getLayerFromImportPath(importPath) {
+  const withoutSlash = importPath.slice(1)
+  const segments = withoutSlash.split('/')
+  if (!segments.length || !segments[0]) return null
+
+  if (segments[0] === 'features' && segments.length > 1) return 'features/' + segments[1]
+  return segments[0]
+}
+
+function findAllowList(layers, sourceLayer) {
+  if (layers[sourceLayer]) return layers[sourceLayer]
+  if (sourceLayer.startsWith('features/') && layers['features/*']) return layers['features/*']
+  return null
+}
+
+function isAllowed(allowList, targetLayer) {
+  return allowList.some(allowed => {
+    if (allowed === targetLayer) return true
+    if (allowed === 'features' && targetLayer.startsWith('features/')) return true
+    if (allowed === 'features/*' && targetLayer.startsWith('features/')) return true
+    return false
+  })
+}

--- a/rules/no-restricted-layer-import/index.js
+++ b/rules/no-restricted-layer-import/index.js
@@ -6,13 +6,19 @@ const messages = {
     `Unexpected import '${importPath}' — '${sourceLayer}' may not import from '${targetLayer}'`,
 }
 
+const sharedRootModules = [
+  'routeMap', 'routeData', 'routeRedirects',
+  'i18n', 'cssGlobal', 'images', 'fonts',
+  'search', 'constants', 'groq', 'head',
+]
+
 const defaultLayers = {
-  'features/buildingBlocks': ['features/buildingBlocks', 'machinery'],
-  'features/*': ['features/*', 'features/buildingBlocks', 'machinery'],
-  'machinery': ['machinery'],
-  'pages': ['pages', 'features', 'machinery', 'templates', 'wrappers'],
-  'templates': ['features', 'machinery'],
-  'wrappers': ['features', 'machinery'],
+  'features/buildingBlocks': ['features/buildingBlocks', 'machinery', ...sharedRootModules],
+  'features/*': ['features/*', 'features/buildingBlocks', 'machinery', ...sharedRootModules],
+  'machinery': ['machinery', ...sharedRootModules],
+  'pages': ['pages', 'features', 'machinery', 'templates', 'wrappers', ...sharedRootModules],
+  'templates': ['features', 'machinery', ...sharedRootModules],
+  'wrappers': ['features', 'machinery', ...sharedRootModules],
 }
 
 module.exports = {

--- a/rules/no-restricted-layer-import/readme.md
+++ b/rules/no-restricted-layer-import/readme.md
@@ -29,8 +29,10 @@ import { Button } from '/features/buildingBlocks/Button'
 
 ## Default Layer Boundaries
 
-| Layer | May import from |
-|-------|----------------|
+All layers can import from shared root modules (`routeMap`, `i18n`, `cssGlobal`, `images`, `search`, `constants`, `groq`, `head`, etc.).
+
+| Layer | May also import from |
+|-------|---------------------|
 | `features/buildingBlocks` | `features/buildingBlocks`, `machinery` |
 | `features/*` | `features/*`, `features/buildingBlocks`, `machinery` |
 | `machinery` | `machinery` |

--- a/rules/no-restricted-layer-import/readme.md
+++ b/rules/no-restricted-layer-import/readme.md
@@ -1,0 +1,52 @@
+# no-restricted-layer-import
+
+Enforce architectural layer boundaries — prevent imports that cross forbidden layer boundaries.
+
+## Rule Details
+
+This rule checks absolute `/`-prefixed imports against configurable layer boundaries. Each architectural layer has an allow-list of layers it may import from.
+
+### ❌ Invalid
+
+```js
+// In machinery/hooks/useX.js — machinery may not import from features
+import { Button } from '/features/buildingBlocks/Button'
+
+// In features/buildingBlocks/Button.js — buildingBlocks may not import from pages
+import { Home } from '/pages/Home'
+```
+
+### ✅ Valid
+
+```js
+// In pages/Home.js — pages may import from features and machinery
+import { Hero } from '/features/hero/HomepageHero'
+import { useTranslate } from '/machinery/I18n'
+
+// In features/hero/Hero.js — features may import from buildingBlocks and machinery
+import { Button } from '/features/buildingBlocks/Button'
+```
+
+## Default Layer Boundaries
+
+| Layer | May import from |
+|-------|----------------|
+| `features/buildingBlocks` | `features/buildingBlocks`, `machinery` |
+| `features/*` | `features/*`, `features/buildingBlocks`, `machinery` |
+| `machinery` | `machinery` |
+| `pages` | `pages`, `features`, `machinery`, `templates`, `wrappers` |
+| `templates` | `features`, `machinery` |
+| `wrappers` | `features`, `machinery` |
+
+## Options
+
+Override the default boundaries with a custom `layers` object:
+
+```js
+'@kaliber/no-restricted-layer-import': ['error', {
+  layers: {
+    'machinery': ['machinery', 'domain'],
+    'pages': ['pages', 'features', 'machinery', 'domain'],
+  }
+}]
+```

--- a/rules/no-restricted-layer-import/test.js
+++ b/rules/no-restricted-layer-import/test.js
@@ -1,0 +1,99 @@
+const { messages } = require('./')
+const { test } = require('../../machinery/test')
+
+test('no-restricted-layer-import', {
+  valid: [
+    // pages → features: allowed
+    {
+      filename: '/project/src/pages/Home.js',
+      code: `import { Hero } from '/features/hero/HomepageHero'`,
+    },
+    // pages → machinery: allowed
+    {
+      filename: '/project/src/pages/Home.js',
+      code: `import { useTranslate } from '/machinery/I18n'`,
+    },
+    // pages → templates: allowed
+    {
+      filename: '/project/src/pages/Home.js',
+      code: `import { PageTemplate } from '/templates/PageTemplate'`,
+    },
+    // features → buildingBlocks: allowed
+    {
+      filename: '/project/src/features/hero/Hero.js',
+      code: `import { Button } from '/features/buildingBlocks/Button'`,
+    },
+    // features → machinery: allowed
+    {
+      filename: '/project/src/features/hero/Hero.js',
+      code: `import { useTranslate } from '/machinery/I18n'`,
+    },
+    // buildingBlocks → buildingBlocks: allowed (same layer)
+    {
+      filename: '/project/src/features/buildingBlocks/Button.js',
+      code: `import { Icon } from '/features/buildingBlocks/Icon'`,
+    },
+    // buildingBlocks → machinery: allowed
+    {
+      filename: '/project/src/features/buildingBlocks/Button.js',
+      code: `import { useTranslate } from '/machinery/I18n'`,
+    },
+    // relative import: skipped
+    {
+      filename: '/project/src/pages/Home.js',
+      code: `import styles from './Home.css'`,
+    },
+    // package import: skipped
+    {
+      filename: '/project/src/pages/Home.js',
+      code: `import config from '@kaliber/config'`,
+    },
+    // machinery → machinery: allowed (same layer)
+    {
+      filename: '/project/src/machinery/hooks/useX.js',
+      code: `import { something } from '/machinery/I18n'`,
+    },
+    // features → features (same feature): allowed
+    {
+      filename: '/project/src/features/hero/HomepageHero.js',
+      code: `import PostcodeSearch from '/features/hero/PostcodeSearch.universal'`,
+    },
+    // unknown layer: not restricted
+    {
+      filename: '/project/src/search/client.js',
+      code: `import { Button } from '/features/buildingBlocks/Button'`,
+    },
+  ],
+  invalid: [
+    // machinery → features: forbidden
+    {
+      filename: '/project/src/machinery/I18n.js',
+      code: `import { Button } from '/features/buildingBlocks/Button'`,
+      errors: [{ message: messages['restricted layer import']('/features/buildingBlocks/Button', 'machinery', 'features/buildingBlocks') }],
+    },
+    // buildingBlocks → pages: forbidden
+    {
+      filename: '/project/src/features/buildingBlocks/Button.js',
+      code: `import { Home } from '/pages/Home'`,
+      errors: [{ message: messages['restricted layer import']('/pages/Home', 'features/buildingBlocks', 'pages') }],
+    },
+    // machinery → features: forbidden (nested machinery file)
+    {
+      filename: '/project/src/machinery/hooks/useX.js',
+      code: `import { Hero } from '/features/hero/Hero'`,
+      errors: [{ message: messages['restricted layer import']('/features/hero/Hero', 'machinery', 'features/hero') }],
+    },
+    // buildingBlocks → other features: forbidden
+    {
+      filename: '/project/src/features/buildingBlocks/Button.js',
+      code: `import { Hero } from '/features/hero/Hero'`,
+      errors: [{ message: messages['restricted layer import']('/features/hero/Hero', 'features/buildingBlocks', 'features/hero') }],
+    },
+    // templates → pages: forbidden
+    {
+      filename: '/project/src/templates/PageTemplate.js',
+      code: `import { Home } from '/pages/Home'`,
+      errors: [{ message: messages['restricted layer import']('/pages/Home', 'templates', 'pages') }],
+    },
+  ],
+})

--- a/rules/no-restricted-layer-import/test.js
+++ b/rules/no-restricted-layer-import/test.js
@@ -1,99 +1,310 @@
 const { messages } = require('./')
-const { test } = require('../../machinery/test')
+const { test, merge } = require('../../machinery/test')
 
-test('no-restricted-layer-import', {
-  valid: [
-    // pages → features: allowed
-    {
-      filename: '/project/src/pages/Home.js',
-      code: `import { Hero } from '/features/hero/HomepageHero'`,
-    },
-    // pages → machinery: allowed
-    {
-      filename: '/project/src/pages/Home.js',
-      code: `import { useTranslate } from '/machinery/I18n'`,
-    },
-    // pages → templates: allowed
-    {
-      filename: '/project/src/pages/Home.js',
-      code: `import { PageTemplate } from '/templates/PageTemplate'`,
-    },
-    // features → buildingBlocks: allowed
-    {
-      filename: '/project/src/features/hero/Hero.js',
-      code: `import { Button } from '/features/buildingBlocks/Button'`,
-    },
-    // features → machinery: allowed
-    {
-      filename: '/project/src/features/hero/Hero.js',
-      code: `import { useTranslate } from '/machinery/I18n'`,
-    },
-    // buildingBlocks → buildingBlocks: allowed (same layer)
-    {
-      filename: '/project/src/features/buildingBlocks/Button.js',
-      code: `import { Icon } from '/features/buildingBlocks/Icon'`,
-    },
-    // buildingBlocks → machinery: allowed
-    {
-      filename: '/project/src/features/buildingBlocks/Button.js',
-      code: `import { useTranslate } from '/machinery/I18n'`,
-    },
-    // relative import: skipped
-    {
-      filename: '/project/src/pages/Home.js',
-      code: `import styles from './Home.css'`,
-    },
-    // package import: skipped
-    {
-      filename: '/project/src/pages/Home.js',
-      code: `import config from '@kaliber/config'`,
-    },
-    // machinery → machinery: allowed (same layer)
-    {
-      filename: '/project/src/machinery/hooks/useX.js',
-      code: `import { something } from '/machinery/I18n'`,
-    },
-    // features → features (same feature): allowed
-    {
-      filename: '/project/src/features/hero/HomepageHero.js',
-      code: `import PostcodeSearch from '/features/hero/PostcodeSearch.universal'`,
-    },
-    // unknown layer: not restricted
-    {
-      filename: '/project/src/search/client.js',
-      code: `import { Button } from '/features/buildingBlocks/Button'`,
-    },
-  ],
-  invalid: [
-    // machinery → features: forbidden
-    {
-      filename: '/project/src/machinery/I18n.js',
-      code: `import { Button } from '/features/buildingBlocks/Button'`,
-      errors: [{ message: messages['restricted layer import']('/features/buildingBlocks/Button', 'machinery', 'features/buildingBlocks') }],
-    },
-    // buildingBlocks → pages: forbidden
-    {
-      filename: '/project/src/features/buildingBlocks/Button.js',
-      code: `import { Home } from '/pages/Home'`,
-      errors: [{ message: messages['restricted layer import']('/pages/Home', 'features/buildingBlocks', 'pages') }],
-    },
-    // machinery → features: forbidden (nested machinery file)
-    {
-      filename: '/project/src/machinery/hooks/useX.js',
-      code: `import { Hero } from '/features/hero/Hero'`,
-      errors: [{ message: messages['restricted layer import']('/features/hero/Hero', 'machinery', 'features/hero') }],
-    },
-    // buildingBlocks → other features: forbidden
-    {
-      filename: '/project/src/features/buildingBlocks/Button.js',
-      code: `import { Hero } from '/features/hero/Hero'`,
-      errors: [{ message: messages['restricted layer import']('/features/hero/Hero', 'features/buildingBlocks', 'features/hero') }],
-    },
-    // templates → pages: forbidden
-    {
-      filename: '/project/src/templates/PageTemplate.js',
-      code: `import { Home } from '/pages/Home'`,
-      errors: [{ message: messages['restricted layer import']('/pages/Home', 'templates', 'pages') }],
-    },
-  ],
-})
+test('no-restricted-layer-import', merge(
+  // ─── Default layers ───────────────────────────────────────────────────────
+  {
+    valid: [
+      // pages → features: allowed
+      {
+        filename: '/project/src/pages/Home.js',
+        code: `import { Hero } from '/features/hero/HomepageHero'`,
+      },
+      // pages → machinery: allowed
+      {
+        filename: '/project/src/pages/Home.js',
+        code: `import { useTranslate } from '/machinery/I18n'`,
+      },
+      // pages → templates: allowed
+      {
+        filename: '/project/src/pages/Home.js',
+        code: `import { PageTemplate } from '/templates/PageTemplate'`,
+      },
+      // pages → wrappers: allowed
+      {
+        filename: '/project/src/pages/Home.js',
+        code: `import { AppWrapper } from '/wrappers/App'`,
+      },
+      // features → buildingBlocks: allowed
+      {
+        filename: '/project/src/features/hero/Hero.js',
+        code: `import { Button } from '/features/buildingBlocks/Button'`,
+      },
+      // features → machinery: allowed
+      {
+        filename: '/project/src/features/hero/Hero.js',
+        code: `import { useTranslate } from '/machinery/I18n'`,
+      },
+      // buildingBlocks → buildingBlocks: allowed (same layer)
+      {
+        filename: '/project/src/features/buildingBlocks/Button.js',
+        code: `import { Icon } from '/features/buildingBlocks/Icon'`,
+      },
+      // buildingBlocks → machinery: allowed
+      {
+        filename: '/project/src/features/buildingBlocks/Button.js',
+        code: `import { useTranslate } from '/machinery/I18n'`,
+      },
+      // machinery → machinery: allowed (same layer)
+      {
+        filename: '/project/src/machinery/hooks/useX.js',
+        code: `import { something } from '/machinery/I18n'`,
+      },
+      // features → features (same feature): allowed
+      {
+        filename: '/project/src/features/hero/HomepageHero.js',
+        code: `import PostcodeSearch from '/features/hero/PostcodeSearch.universal'`,
+      },
+      // templates → features: allowed
+      {
+        filename: '/project/src/templates/PageTemplate.js',
+        code: `import { Hero } from '/features/hero/Hero'`,
+      },
+      // templates → machinery: allowed
+      {
+        filename: '/project/src/templates/PageTemplate.js',
+        code: `import { useTranslate } from '/machinery/I18n'`,
+      },
+      // wrappers → features: allowed
+      {
+        filename: '/project/src/wrappers/App.js',
+        code: `import { Navigation } from '/features/navigation/Navigation'`,
+      },
+      // wrappers → machinery: allowed
+      {
+        filename: '/project/src/wrappers/App.js',
+        code: `import { useTranslate } from '/machinery/I18n'`,
+      },
+      // relative import: skipped (not absolute path)
+      {
+        filename: '/project/src/pages/Home.js',
+        code: `import styles from './Home.css'`,
+      },
+      // package import: skipped (doesn't start with /)
+      {
+        filename: '/project/src/pages/Home.js',
+        code: `import config from '@kaliber/config'`,
+      },
+      // unknown layer: not restricted (no allow-list defined)
+      {
+        filename: '/project/src/search/client.js',
+        code: `import { Button } from '/features/buildingBlocks/Button'`,
+      },
+      // shared root module: always allowed from any layer
+      {
+        filename: '/project/src/features/hero/Hero.js',
+        code: `import routeMap from '/routeMap'`,
+      },
+      {
+        filename: '/project/src/machinery/I18n.js',
+        code: `import { translations } from '/i18n/translations'`,
+      },
+      {
+        filename: '/project/src/features/buildingBlocks/Button.js',
+        code: `import { colors } from '/cssGlobal/colors'`,
+      },
+      // re-export: valid direction
+      {
+        filename: '/project/src/features/hero/Hero.js',
+        code: `export { Button } from '/features/buildingBlocks/Button'`,
+      },
+      // export all: valid direction
+      {
+        filename: '/project/src/features/hero/Hero.js',
+        code: `export * from '/features/buildingBlocks/Button'`,
+      },
+    ],
+    invalid: [
+      // machinery → features: forbidden
+      {
+        filename: '/project/src/machinery/I18n.js',
+        code: `import { Button } from '/features/buildingBlocks/Button'`,
+        errors: [{ message: messages['restricted layer import']('/features/buildingBlocks/Button', 'machinery', 'features/buildingBlocks') }],
+      },
+      // buildingBlocks → pages: forbidden
+      {
+        filename: '/project/src/features/buildingBlocks/Button.js',
+        code: `import { Home } from '/pages/Home'`,
+        errors: [{ message: messages['restricted layer import']('/pages/Home', 'features/buildingBlocks', 'pages') }],
+      },
+      // machinery → features (nested machinery file): forbidden
+      {
+        filename: '/project/src/machinery/hooks/useX.js',
+        code: `import { Hero } from '/features/hero/Hero'`,
+        errors: [{ message: messages['restricted layer import']('/features/hero/Hero', 'machinery', 'features/hero') }],
+      },
+      // buildingBlocks → other features: forbidden
+      {
+        filename: '/project/src/features/buildingBlocks/Button.js',
+        code: `import { Hero } from '/features/hero/Hero'`,
+        errors: [{ message: messages['restricted layer import']('/features/hero/Hero', 'features/buildingBlocks', 'features/hero') }],
+      },
+      // templates → pages: forbidden
+      {
+        filename: '/project/src/templates/PageTemplate.js',
+        code: `import { Home } from '/pages/Home'`,
+        errors: [{ message: messages['restricted layer import']('/pages/Home', 'templates', 'pages') }],
+      },
+      // features → pages: forbidden
+      {
+        filename: '/project/src/features/hero/Hero.js',
+        code: `import { Home } from '/pages/Home'`,
+        errors: [{ message: messages['restricted layer import']('/pages/Home', 'features/hero', 'pages') }],
+      },
+      // features → templates: forbidden
+      {
+        filename: '/project/src/features/hero/Hero.js',
+        code: `import { PageTemplate } from '/templates/PageTemplate'`,
+        errors: [{ message: messages['restricted layer import']('/templates/PageTemplate', 'features/hero', 'templates') }],
+      },
+      // features → wrappers: forbidden
+      {
+        filename: '/project/src/features/hero/Hero.js',
+        code: `import { AppWrapper } from '/wrappers/App'`,
+        errors: [{ message: messages['restricted layer import']('/wrappers/App', 'features/hero', 'wrappers') }],
+      },
+      // machinery → pages: forbidden
+      {
+        filename: '/project/src/machinery/I18n.js',
+        code: `import { Home } from '/pages/Home'`,
+        errors: [{ message: messages['restricted layer import']('/pages/Home', 'machinery', 'pages') }],
+      },
+      // re-export also flagged
+      {
+        filename: '/project/src/machinery/I18n.js',
+        code: `export { Button } from '/features/buildingBlocks/Button'`,
+        errors: [{ message: messages['restricted layer import']('/features/buildingBlocks/Button', 'machinery', 'features/buildingBlocks') }],
+      },
+      // export all also flagged
+      {
+        filename: '/project/src/machinery/I18n.js',
+        code: `export * from '/features/hero/Hero'`,
+        errors: [{ message: messages['restricted layer import']('/features/hero/Hero', 'machinery', 'features/hero') }],
+      },
+      // wrappers → pages: forbidden
+      {
+        filename: '/project/src/wrappers/App.js',
+        code: `import { Home } from '/pages/Home'`,
+        errors: [{ message: messages['restricted layer import']('/pages/Home', 'wrappers', 'pages') }],
+      },
+      // buildingBlocks → templates: forbidden
+      {
+        filename: '/project/src/features/buildingBlocks/Button.js',
+        code: `import { PageTemplate } from '/templates/PageTemplate'`,
+        errors: [{ message: messages['restricted layer import']('/templates/PageTemplate', 'features/buildingBlocks', 'templates') }],
+      },
+    ],
+  },
+
+  // ─── Custom layers ────────────────────────────────────────────────────────
+  {
+    valid: [
+      // Custom layer 'domain' added — pages → domain: allowed
+      {
+        filename: '/project/src/pages/Home.js',
+        code: `import { getLabels } from '/domain/labels'`,
+        options: [{ layers: {
+          'pages': ['pages', 'features', 'machinery', 'domain'],
+          'domain': ['domain', 'machinery'],
+        }}],
+      },
+      // Shared root modules still allowed with custom layers
+      {
+        filename: '/project/src/pages/Home.js',
+        code: `import routeMap from '/routeMap'`,
+        options: [{ layers: {
+          'pages': ['pages', 'features', 'machinery', 'domain'],
+        }}],
+      },
+      // Shared root modules allowed for custom layers
+      {
+        filename: '/project/src/domain/labels.js',
+        code: `import { something } from '/i18n/translations'`,
+        options: [{ layers: {
+          'domain': ['domain', 'machinery'],
+        }}],
+      },
+      // Default layers preserved when custom layers only add new ones
+      {
+        filename: '/project/src/features/hero/Hero.js',
+        code: `import { Button } from '/features/buildingBlocks/Button'`,
+        options: [{ layers: {
+          'domain': ['domain', 'machinery'],
+        }}],
+      },
+    ],
+    invalid: [
+      // Custom layer boundaries still enforced
+      {
+        filename: '/project/src/domain/labels.js',
+        code: `import { Hero } from '/features/hero/Hero'`,
+        options: [{ layers: {
+          'domain': ['domain', 'machinery'],
+        }}],
+        errors: [{ message: messages['restricted layer import']('/features/hero/Hero', 'domain', 'features/hero') }],
+      },
+      // Default restrictions still apply with custom layers
+      {
+        filename: '/project/src/machinery/hooks/useX.js',
+        code: `import { Button } from '/features/buildingBlocks/Button'`,
+        options: [{ layers: {
+          'domain': ['domain', 'machinery'],
+        }}],
+        errors: [{ message: messages['restricted layer import']('/features/buildingBlocks/Button', 'machinery', 'features/buildingBlocks') }],
+      },
+    ],
+  },
+
+  // ─── Custom sublayer parents (generalized /* pattern) ─────────────────────
+  {
+    valid: [
+      // domain/* as sublayer parent — domain/auth can import domain/shared
+      {
+        filename: '/project/src/domain/auth/login.js',
+        code: `import { validate } from '/domain/shared/validation'`,
+        options: [{ layers: {
+          'domain/shared': ['domain/shared', 'machinery'],
+          'domain/*': ['domain/*', 'domain/shared', 'machinery'],
+        }}],
+      },
+      // domain/* can import machinery
+      {
+        filename: '/project/src/domain/auth/login.js',
+        code: `import { useTranslate } from '/machinery/I18n'`,
+        options: [{ layers: {
+          'domain/*': ['domain/*', 'machinery'],
+        }}],
+      },
+      // Multiple sublayer parents — both features/* and domain/*
+      {
+        filename: '/project/src/domain/users/profile.js',
+        code: `import { validate } from '/domain/shared/validation'`,
+        options: [{ layers: {
+          'domain/shared': ['domain/shared', 'machinery'],
+          'domain/*': ['domain/*', 'domain/shared', 'machinery'],
+        }}],
+      },
+    ],
+    invalid: [
+      // domain/* → features: forbidden when not in allow-list
+      {
+        filename: '/project/src/domain/auth/login.js',
+        code: `import { Button } from '/features/buildingBlocks/Button'`,
+        options: [{ layers: {
+          'domain/*': ['domain/*', 'machinery'],
+        }}],
+        errors: [{ message: messages['restricted layer import']('/features/buildingBlocks/Button', 'domain/auth', 'features/buildingBlocks') }],
+      },
+      // domain/shared → domain/auth: forbidden (shared is lower layer)
+      {
+        filename: '/project/src/domain/shared/validation.js',
+        code: `import { login } from '/domain/auth/login'`,
+        options: [{ layers: {
+          'domain/shared': ['domain/shared', 'machinery'],
+          'domain/*': ['domain/*', 'domain/shared', 'machinery'],
+        }}],
+        errors: [{ message: messages['restricted layer import']('/domain/auth/login', 'domain/shared', 'domain/auth') }],
+      },
+    ],
+  },
+))

--- a/rules/no-universal-in-universal/index.js
+++ b/rules/no-universal-in-universal/index.js
@@ -1,0 +1,49 @@
+const docsUrl = require('../../machinery/docsUrl')
+
+const messages = {
+  'universal in universal': (componentName) =>
+    `Unexpected universal component '${componentName}' rendered inside a universal file — universal components create separate hydration boundaries and must not be nested`,
+}
+
+module.exports = {
+  messages,
+
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow rendering universal components inside other universal files',
+      url: docsUrl(__dirname),
+    },
+  },
+
+  create(context) {
+    if (!context.filename.endsWith('.universal.js')) return {}
+
+    const universalImports = new Map()
+
+    return {
+      ImportDeclaration(node) {
+        const source = node.source.value
+        if (!source.endsWith('.universal')) return
+
+        for (const specifier of node.specifiers) {
+          universalImports.set(specifier.local.name, source)
+        }
+      },
+
+      JSXOpeningElement(node) {
+        const { name } = node
+        const elementName = name.type === 'JSXIdentifier' ? name.name
+          : name.type === 'JSXMemberExpression' ? name.property.name
+          : null
+
+        if (!elementName || !universalImports.has(elementName)) return
+
+        context.report({
+          message: messages['universal in universal'](elementName),
+          node,
+        })
+      },
+    }
+  },
+}

--- a/rules/no-universal-in-universal/index.js
+++ b/rules/no-universal-in-universal/index.js
@@ -40,7 +40,7 @@ module.exports = {
       JSXOpeningElement(node) {
         const { name } = node
         const elementName = name.type === 'JSXIdentifier' ? name.name
-          : name.type === 'JSXMemberExpression' ? name.property.name
+          : name.type === 'JSXMemberExpression' ? name.object.name
           : null
 
         if (!elementName || !universalImports.has(elementName)) return

--- a/rules/no-universal-in-universal/index.js
+++ b/rules/no-universal-in-universal/index.js
@@ -1,8 +1,12 @@
+const { relative } = require('node:path')
 const docsUrl = require('../../machinery/docsUrl')
+const { getImportGraph } = require('../../machinery/importGraph')
 
 const messages = {
   'universal in universal': (componentName) =>
     `Unexpected universal component '${componentName}' rendered inside a universal file — universal components create separate hydration boundaries and must not be nested`,
+  'transitive universal nesting': (chain) =>
+    `Transitive universal nesting — this file reaches another .universal.js through: ${chain}`,
 }
 
 module.exports = {
@@ -20,12 +24,14 @@ module.exports = {
     if (!context.filename.endsWith('.universal.js')) return {}
 
     const universalImports = new Map()
+    const directUniversalSources = new Set()
 
     return {
       ImportDeclaration(node) {
         const source = node.source.value
         if (!source.endsWith('.universal')) return
 
+        directUniversalSources.add(source)
         for (const specifier of node.specifiers) {
           universalImports.set(specifier.local.name, source)
         }
@@ -43,6 +49,34 @@ module.exports = {
           message: messages['universal in universal'](elementName),
           node,
         })
+      },
+
+      'Program:exit'() {
+        const cwd = context.getCwd ? context.getCwd() : process.cwd()
+        const graph = getImportGraph(cwd)
+        if (!graph) return
+
+        const relPath = relative(cwd, context.filename)
+        const allDeps = graph.transitiveDeps(relPath)
+
+        for (const dep of allDeps) {
+          if (!dep.endsWith('.universal.js')) continue
+
+          // Skip if already caught by the direct check
+          const depWithoutExtension = dep.replace(/\.js$/, '')
+          const isDirectImport = [...directUniversalSources].some(
+            source => depWithoutExtension.endsWith(source.replace(/^\//, ''))
+          )
+          if (isDirectImport) continue
+
+          const chain = graph.findChain(relPath, dep)
+          if (!chain) continue
+
+          context.report({
+            message: messages['transitive universal nesting'](chain.join(' → ')),
+            loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+          })
+        }
       },
     }
   },

--- a/rules/no-universal-in-universal/readme.md
+++ b/rules/no-universal-in-universal/readme.md
@@ -44,3 +44,16 @@ export default function Menu() {
   return <Button />
 }
 ```
+
+## Transitive detection
+
+This rule also detects **transitive** universal nesting — when a `.universal.js` file reaches another `.universal.js` through intermediate non-universal files:
+
+```
+Outer.universal.js → Wrapper.js → Inner.universal.js
+                                        ↑
+                                   caught by transitive check
+```
+
+This uses the esbuild metafile that `@kaliber/build` writes to `.kaliber-build/server-metafile.json`. If the metafile doesn't exist (build hasn't run yet), the rule gracefully falls back to direct-only checking.
+

--- a/rules/no-universal-in-universal/readme.md
+++ b/rules/no-universal-in-universal/readme.md
@@ -1,0 +1,46 @@
+# No universal in universal
+
+Disallow rendering `.universal` components inside other `.universal.js` files.
+
+## Why
+
+In `@kaliber/build`, `.universal.js` files create separate client-side hydration boundaries. When you render a universal component inside another universal file, you get nested hydration boundaries — the inner component will be hydrated twice, once as part of the outer boundary and once as its own boundary. This causes duplicate mounting, wasted resources, and potential state conflicts.
+
+Each universal component should be rendered from a regular (non-universal) file, such as a page or a plain component.
+
+## Examples
+
+Example of *incorrect* code:
+
+```jsx
+// features/Outer.universal.js
+import Inner from '/features/Inner.universal'
+
+export default function Outer() {
+  return (
+    <div>
+      <Inner /> {/* ← nested hydration boundary */}
+    </div>
+  )
+}
+```
+
+Example of *correct* code:
+
+```jsx
+// pages/Home.js (non-universal)
+import Menu from '/features/Menu.universal'
+
+function Home() {
+  return <Menu />
+}
+```
+
+```jsx
+// features/Menu.universal.js
+import { Button } from '/features/buildingBlocks/Button'
+
+export default function Menu() {
+  return <Button />
+}
+```

--- a/rules/no-universal-in-universal/test.js
+++ b/rules/no-universal-in-universal/test.js
@@ -1,5 +1,9 @@
 const { messages } = require('./')
 const { test } = require('../../machinery/test')
+const { getImportGraph, _resetCache } = require('../../machinery/importGraph')
+const { writeFileSync, mkdirSync, rmSync } = require('node:fs')
+const { join } = require('node:path')
+const { describe, it, afterEach } = require('node:test')
 
 test('no-universal-in-universal', {
   valid: [
@@ -34,3 +38,83 @@ test('no-universal-in-universal', {
     },
   ],
 })
+
+// ─── Transitive detection tests ─────────────────────────────────────────────
+
+describe('no-universal-in-universal (transitive)', () => {
+  const projectRoot = join(__dirname, '..', '..', '.test-fixtures', 'transitive-universal')
+
+  afterEach(() => {
+    _resetCache()
+    try { rmSync(projectRoot, { recursive: true, force: true }) } catch {}
+  })
+
+  it('detects transitive universal nesting through a regular file', () => {
+    writeMetafile(projectRoot, {
+      inputs: {
+        'src/features/Outer.universal.js': {
+          imports: [{ path: 'src/features/Wrapper.js' }],
+        },
+        'src/features/Wrapper.js': {
+          imports: [{ path: 'src/features/Inner.universal.js' }],
+        },
+        'src/features/Inner.universal.js': {
+          imports: [],
+        },
+      },
+    })
+
+    const { getImportGraph } = require('../../machinery/importGraph')
+    const graph = getImportGraph(projectRoot)
+
+    const deps = graph.transitiveDeps('src/features/Outer.universal.js')
+    const universalDeps = [...deps].filter(d => d.endsWith('.universal.js'))
+
+    require('node:assert').strictEqual(universalDeps.length, 1)
+    require('node:assert').strictEqual(universalDeps[0], 'src/features/Inner.universal.js')
+
+    const chain = graph.findChain('src/features/Outer.universal.js', 'src/features/Inner.universal.js')
+    require('node:assert').deepStrictEqual(chain, [
+      'src/features/Outer.universal.js',
+      'src/features/Wrapper.js',
+      'src/features/Inner.universal.js',
+    ])
+  })
+
+  it('does not flag non-universal transitive dependencies', () => {
+    writeMetafile(projectRoot, {
+      inputs: {
+        'src/features/Outer.universal.js': {
+          imports: [{ path: 'src/features/Wrapper.js' }],
+        },
+        'src/features/Wrapper.js': {
+          imports: [{ path: 'src/machinery/hooks.js' }],
+        },
+        'src/machinery/hooks.js': {
+          imports: [],
+        },
+      },
+    })
+
+    const { getImportGraph } = require('../../machinery/importGraph')
+    const graph = getImportGraph(projectRoot)
+
+    const deps = graph.transitiveDeps('src/features/Outer.universal.js')
+    const universalDeps = [...deps].filter(d => d.endsWith('.universal.js'))
+
+    require('node:assert').strictEqual(universalDeps.length, 0)
+  })
+
+  it('returns null when no metafile exists', () => {
+    const { getImportGraph } = require('../../machinery/importGraph')
+    const graph = getImportGraph('/nonexistent/path')
+
+    require('node:assert').strictEqual(graph, null)
+  })
+})
+
+function writeMetafile(projectRoot, metafile) {
+  const dir = join(projectRoot, '.kaliber-build')
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'server-metafile.json'), JSON.stringify(metafile))
+}

--- a/rules/no-universal-in-universal/test.js
+++ b/rules/no-universal-in-universal/test.js
@@ -1,9 +1,7 @@
 const { messages } = require('./')
 const { test } = require('../../machinery/test')
-const { getImportGraph, _resetCache } = require('../../machinery/importGraph')
-const { writeFileSync, mkdirSync, rmSync } = require('node:fs')
-const { join } = require('node:path')
-const { describe, it, afterEach } = require('node:test')
+
+// ─── Direct detection (AST-level, via RuleTester) ───────────────────────────
 
 test('no-universal-in-universal', {
   valid: [
@@ -22,6 +20,21 @@ test('no-universal-in-universal', {
       filename: '/project/src/features/Wrapper.universal.js',
       code: `import Inner from '/features/Inner.universal'\nexport default Inner`,
     },
+    // Non-universal file: no checks at all
+    {
+      filename: '/project/src/features/Hero.js',
+      code: `import Inner from '/features/Inner.universal'\nexport default function Hero() { return <Inner /> }`,
+    },
+    // Universal file with default import from non-universal
+    {
+      filename: '/project/src/features/Menu.universal.js',
+      code: `import styles from './Menu.css'\nexport default function Menu() { return <div className={styles.root} /> }`,
+    },
+    // Universal file with namespace import from universal (not rendered)
+    {
+      filename: '/project/src/features/Wrapper.universal.js',
+      code: `import * as Inner from '/features/Inner.universal'\nexport default Inner.Component`,
+    },
   ],
   invalid: [
     // Universal file importing AND rendering another universal component
@@ -36,85 +49,21 @@ test('no-universal-in-universal', {
       code: `import { Inner } from '/features/Inner.universal'\nexport default function Outer() { return <Inner /> }`,
       errors: [{ message: messages['universal in universal']('Inner') }],
     },
+    // Universal file rendering via JSXMemberExpression
+    {
+      filename: '/project/src/features/Outer.universal.js',
+      code: `import * as Inner from '/features/Inner.universal'\nexport default function Outer() { return <Inner.Component /> }`,
+      errors: [{ message: messages['universal in universal']('Inner') }],
+    },
+    // Multiple universal imports, only rendered ones flagged
+    {
+      filename: '/project/src/features/Outer.universal.js',
+      code: `import A from '/features/A.universal'\nimport B from '/features/B.universal'\nexport default function Outer() { return <A /> }`,
+      errors: [{ message: messages['universal in universal']('A') }],
+    },
   ],
 })
 
-// ─── Transitive detection tests ─────────────────────────────────────────────
-
-describe('no-universal-in-universal (transitive)', () => {
-  const projectRoot = join(__dirname, '..', '..', '.test-fixtures', 'transitive-universal')
-
-  afterEach(() => {
-    _resetCache()
-    try { rmSync(projectRoot, { recursive: true, force: true }) } catch {}
-  })
-
-  it('detects transitive universal nesting through a regular file', () => {
-    writeMetafile(projectRoot, {
-      inputs: {
-        'src/features/Outer.universal.js': {
-          imports: [{ path: 'src/features/Wrapper.js' }],
-        },
-        'src/features/Wrapper.js': {
-          imports: [{ path: 'src/features/Inner.universal.js' }],
-        },
-        'src/features/Inner.universal.js': {
-          imports: [],
-        },
-      },
-    })
-
-    const { getImportGraph } = require('../../machinery/importGraph')
-    const graph = getImportGraph(projectRoot)
-
-    const deps = graph.transitiveDeps('src/features/Outer.universal.js')
-    const universalDeps = [...deps].filter(d => d.endsWith('.universal.js'))
-
-    require('node:assert').strictEqual(universalDeps.length, 1)
-    require('node:assert').strictEqual(universalDeps[0], 'src/features/Inner.universal.js')
-
-    const chain = graph.findChain('src/features/Outer.universal.js', 'src/features/Inner.universal.js')
-    require('node:assert').deepStrictEqual(chain, [
-      'src/features/Outer.universal.js',
-      'src/features/Wrapper.js',
-      'src/features/Inner.universal.js',
-    ])
-  })
-
-  it('does not flag non-universal transitive dependencies', () => {
-    writeMetafile(projectRoot, {
-      inputs: {
-        'src/features/Outer.universal.js': {
-          imports: [{ path: 'src/features/Wrapper.js' }],
-        },
-        'src/features/Wrapper.js': {
-          imports: [{ path: 'src/machinery/hooks.js' }],
-        },
-        'src/machinery/hooks.js': {
-          imports: [],
-        },
-      },
-    })
-
-    const { getImportGraph } = require('../../machinery/importGraph')
-    const graph = getImportGraph(projectRoot)
-
-    const deps = graph.transitiveDeps('src/features/Outer.universal.js')
-    const universalDeps = [...deps].filter(d => d.endsWith('.universal.js'))
-
-    require('node:assert').strictEqual(universalDeps.length, 0)
-  })
-
-  it('returns null when no metafile exists', () => {
-    const { getImportGraph } = require('../../machinery/importGraph')
-    const graph = getImportGraph('/nonexistent/path')
-
-    require('node:assert').strictEqual(graph, null)
-  })
-})
-
-function writeMetafile(projectRoot, metafile) {
-  const dir = join(projectRoot, '.kaliber-build')
-  mkdirSync(dir, { recursive: true })
-  writeFileSync(join(dir, 'server-metafile.json'), JSON.stringify(metafile))
-}
+// Transitive detection is tested via the comprehensive importGraph.test.js
+// which covers: circular deps, diamond deps, deep chains, realistic Kaliber
+// project structures, and sneaky nesting via shared buildingBlocks.

--- a/rules/no-universal-in-universal/test.js
+++ b/rules/no-universal-in-universal/test.js
@@ -1,0 +1,36 @@
+const { messages } = require('./')
+const { test } = require('../../machinery/test')
+
+test('no-universal-in-universal', {
+  valid: [
+    // Non-universal file importing and rendering a universal component
+    {
+      filename: '/project/src/pages/Home.js',
+      code: `import Menu from '/features/Menu.universal'\nfunction Home() { return <Menu /> }`,
+    },
+    // Universal file importing non-universal components
+    {
+      filename: '/project/src/features/Menu.universal.js',
+      code: `import { Button } from '/features/buildingBlocks/Button'\nexport default function Menu() { return <Button /> }`,
+    },
+    // Universal file importing a universal but not rendering it (re-export)
+    {
+      filename: '/project/src/features/Wrapper.universal.js',
+      code: `import Inner from '/features/Inner.universal'\nexport default Inner`,
+    },
+  ],
+  invalid: [
+    // Universal file importing AND rendering another universal component
+    {
+      filename: '/project/src/features/Outer.universal.js',
+      code: `import Inner from '/features/Inner.universal'\nexport default function Outer() { return <div><Inner /></div> }`,
+      errors: [{ message: messages['universal in universal']('Inner') }],
+    },
+    // Universal file with named import from universal
+    {
+      filename: '/project/src/features/Outer.universal.js',
+      code: `import { Inner } from '/features/Inner.universal'\nexport default function Outer() { return <Inner /> }`,
+      errors: [{ message: messages['universal in universal']('Inner') }],
+    },
+  ],
+})


### PR DESCRIPTION
Cherry-picked from `feature/no-duplicate-code` — just the architecture rules, without the duplicate code engine (superseded by the semantic clone engine).

## Rules added

### `no-restricted-layer-import`
Enforce architectural layer boundaries — prevents imports that cross forbidden layer boundaries (e.g. `machinery/` importing from `features/`).

### `no-nested-component`
Prevent specific React components from being nested inside each other (e.g. `Container` inside `Container`, `Heading` inside `Heading`).

### `no-universal-in-universal`
Disallow rendering universal components inside other universal files — universal components create separate hydration boundaries and must not be nested.

## What's NOT included

The `no-duplicate-code` rule and its 400-line text-based engine have been dropped — the semantic clone engine (`semantic-clone-research`) fully supersedes it with Type 1–4 detection via AI embeddings + a VS Code extension.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an architecture-focused lint preset with new checks for import boundary violations, disallowed nested React component patterns, and “universal” component nesting.
  * Improved detection of component ancestry and source-layer context to support more precise linting.
* **Documentation**
  * Documented the new lint rules and their configuration options.
* **Tests**
  * Added comprehensive test coverage for the new preset rules and import-graph behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->